### PR TITLE
Animation Hook Adjustments

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -55,39 +55,6 @@ std::mt19937 mtMersenneTwister(rdRandomDevice());
 // Statics
 static DWORD dwDummy;
 
-// TODO: Bring this bit of code up to standard with the rest of the project. It's literally the
-// oldest hook in sc2kfix and its the kind of quick-and-dirty thing I'd rather rewrite to be more
-// digestible. We can hook anything in the game, we don't need to jam hand-assembled code into
-// code segments anymore.
-// 
-// This code replaces the original stack cleanup and return after the engine
-// cycles the animation palette.
-// 
-// 6881000000      push dword 0x81              ; flags = RDW_INVALIDATE | RDW_ALLCHILDREN
-// 6A00            push 0                       ; hrgnUpdate = NULL
-// 6A00            push 0                       ; lprcUpdate = NULL
-// 8B0D2C704C00    mov ecx, [pCWndRootWindow]
-// 8B511C          mov edx, [ecx+0x1C]
-// 52              push edx                     ; hWnd
-// FF155CFD4E00    call [RedrawWindow]
-// 5D              pop ebp                      ; Clean up stack and return
-// 5F              pop edi
-// 5E              pop esi
-// 5B              pop ebx
-// C3              retn
-BYTE bAnimationPatch1996[30] = {
-	0x68, 0x81, 0x00, 0x00, 0x00, 0x6A, 0x00, 0x6A, 0x00, 0x8B, 0x0D, 0x2C,
-	0x70, 0x4C, 0x00, 0x8B, 0x51, 0x1C, 0x52, 0xFF, 0x15, 0x5C, 0xFD, 0x4E,
-	0x00, 0x5D, 0x5F, 0x5E, 0x5B, 0xC3
-};
-
-// Same as above, but with the offsets adjusted for the 1995 EXE
-BYTE bAnimationPatch1995[30] = {
-	0x68, 0x81, 0x00, 0x00, 0x00, 0x6A, 0x00, 0x6A, 0x00, 0x8B, 0x0D, 0x2C,
-	0x60, 0x4C, 0x00, 0x8B, 0x51, 0x1C, 0x52, 0xFF, 0x15, 0xE8, 0xEC, 0x4E,
-	0x00, 0x5D, 0x5F, 0x5E, 0x5B, 0xC3
-};
-
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 	int argc = 0;
 	LPWSTR* argv = NULL;
@@ -282,26 +249,18 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 		}
 
 		// Palette animation fix
-		LPVOID lpAnimationFix;
-		PBYTE lpAnimationFixSrc;
-		UINT uAnimationFixLength;
-		switch (dwDetectedVersion) {
-		case SC2KVERSION_1995:
-			lpAnimationFix = (LPVOID)0x00456B23;
-			lpAnimationFixSrc = bAnimationPatch1995;
-			uAnimationFixLength = 30;
-			break;
+		BOOL bCanFixAnimation;
 
-		case SC2KVERSION_1996:
-		default:
-			lpAnimationFix = (LPVOID)0x004571D3;
-			lpAnimationFixSrc = bAnimationPatch1996;
-			uAnimationFixLength = 30;
-		}
-		
-		VirtualProtect(lpAnimationFix, uAnimationFixLength, PAGE_EXECUTE_READWRITE, &dwDummy);
-		memcpy(lpAnimationFix, lpAnimationFixSrc, uAnimationFixLength);
-		ConsoleLog(LOG_INFO, "CORE: Patched palette animation fix.\n");
+		bCanFixAnimation = TRUE;
+		if (dwDetectedVersion == SC2KVERSION_1996)
+			InstallAnimationSimCity1996Hooks();
+		else if (dwDetectedVersion == SC2KVERSION_1995)
+			InstallAnimationSimCity1995Hooks();
+		else
+			bCanFixAnimation = FALSE;
+
+		if (bCanFixAnimation)
+			ConsoleLog(LOG_INFO, "CORE: Patched palette animation fix.\n");
 
 		// Dialog crash fix - hat tip to Aleksander Krimsky (@alekasm on GitHub)
 		LPVOID lpDialogFix1;

--- a/hooks/hook_animation.cpp
+++ b/hooks/hook_animation.cpp
@@ -1,0 +1,44 @@
+// sc2kfix hooks/hook_animation.cpp: hooks to do with animations across the various
+// supported versions of SimCity 2000.
+// (c) 2025 sc2kfix project (https://sc2kfix.net) - released under the MIT license
+
+#undef UNICODE
+#include <windows.h>
+#include <psapi.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <sc2kfix.h>
+
+static DWORD dwDummy;
+
+extern "C" int __cdecl Hook_AnimationFunctionSimCity1996(HPALETTE *hP1, int iToggle) {
+	int(__cdecl *H_AnimationFunction1996)(HPALETTE *, int) = (int(__cdecl *)(HPALETTE *, int))0x457110;
+
+	int ret = H_AnimationFunction1996(hP1, iToggle);
+	RedrawWindow(GameGetRootWindowHandle(), NULL, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN);
+
+	return ret;
+}
+
+extern "C" int __cdecl Hook_AnimationFunctionSimCity1995(HPALETTE *hP1, int iToggle) {
+	void *&pRootWnd1995 = *(void **)0x4C602C;
+	HWND hMainWnd = (HWND)((DWORD*)pRootWnd1995)[7];
+
+	int(__cdecl *H_AnimationFunction1995)(HPALETTE *, int) = (int(__cdecl *)(HPALETTE *, int))0x456A60;
+
+	int ret = H_AnimationFunction1995(hP1, iToggle);
+	RedrawWindow(hMainWnd, NULL, NULL, RDW_INVALIDATE | RDW_ALLCHILDREN);
+
+	return ret;
+}
+
+void InstallAnimationSimCity1996Hooks(void) {
+	VirtualProtect((LPVOID)0x4023D3, 5, PAGE_EXECUTE_READWRITE, &dwDummy);
+	NEWJMP((LPVOID)0x4023D3, Hook_AnimationFunctionSimCity1996);
+}
+
+void InstallAnimationSimCity1995Hooks(void) {
+	VirtualProtect((LPVOID)0x402405, 5, PAGE_EXECUTE_READWRITE, &dwDummy);
+	NEWJMP((LPVOID)0x402405, Hook_AnimationFunctionSimCity1995);
+}

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -305,6 +305,8 @@ HOOKEXT BOOL bHookStopProcessing;
 
 // Hooks to inject in dllmain.cpp
 
+void InstallAnimationSimCity1996Hooks(void);
+void InstallAnimationSimCity1995Hooks(void);
 void InstallMiscHooks(void);
 void UpdateMiscHooks(void);
 void InstallQueryHooks(void);

--- a/sc2kfix.vcxproj
+++ b/sc2kfix.vcxproj
@@ -92,6 +92,7 @@
     <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="hooks\hook_animation.cpp" />
     <ClCompile Include="kuroko\builtins.c" />
     <ClCompile Include="kuroko\chunk.c" />
     <ClCompile Include="kuroko\compiler.c" />

--- a/sc2kfix.vcxproj.filters
+++ b/sc2kfix.vcxproj.filters
@@ -317,6 +317,9 @@
     <ClCompile Include="modules\sc2x.cpp">
       <Filter>Source Files\Modules</Filter>
     </ClCompile>
+    <ClCompile Include="hooks\hook_animation.cpp">
+      <Filter>Source Files\Hooks</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="sc2kfix.rc">


### PR DESCRIPTION
Both the 1995 and 1996 SimCity 2000 animation hooks have been adjusted.

They both use locally-defined game functions (only the 1995 version also uses its locally-defined root window handler).

Hopefully this is of some use.

I have verified that the new versions of the animation hook are functional in the referenced versions while testing on this system.