### PR TITLE
Cursor Handling Tweaks.

### DIFF
--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -1878,6 +1878,21 @@ extern "C" __int16 __cdecl Hook_MapToolMenuAction(int iMouseKeys, POINT pt) {
 	return ret;
 }
 
+extern "C" void __stdcall Hook_LoadCursorResources() {
+	DWORD pThis;
+
+	__asm mov[pThis], ecx
+
+	void(__thiscall *H_LoadCursorResources)(void *) = (void(__thiscall *)(void *))0x4255A0;
+
+	HDC hDC;
+
+	hDC = GetDC(0);
+	((DWORD *)pThis)[57] = GetDeviceCaps(hDC, HORZRES);
+	ReleaseDC(0, hDC);
+	H_LoadCursorResources((void *)pThis);
+}
+
 // Placeholder.
 void ShowModSettingsDialog(void) {
 	MessageBox(NULL, "The mod settings dialog has not yet been implemented. Check back later.", "sc2fix", MB_OK);
@@ -2239,6 +2254,10 @@ skipdebugmenu:
 	// Hook for the MapToolMenuAction call.
 	VirtualProtect((LPVOID)0x402B44, 5, PAGE_EXECUTE_READWRITE, &dwDummy);
 	NEWJMP((LPVOID)0x402B44, Hook_MapToolMenuAction);
+
+	// Hook for CSimcityApp::LoadCursorResources
+	VirtualProtect((LPVOID)0x402234, 5, PAGE_EXECUTE_READWRITE, &dwDummy);
+	NEWJMP((LPVOID)0x402234, Hook_LoadCursorResources);
 
 	// Add hook to center with the middle mouse button
 	AFX_MSGMAP_ENTRY afxMessageMapEntrySimCityView = {

--- a/include/sc2k_1996.h
+++ b/include/sc2k_1996.h
@@ -964,6 +964,7 @@ GAMECALL(0x402B2B, int, __cdecl, MapToolStretchTerrain, __int16 iTileTargetX, __
 GAMECALL(0x402B44, __int16, __cdecl, MapToolMenuAction, int iMouseKeys, POINT pt)
 GAMECALL(0x402B94, int, __cdecl, MapToolLevelTerrain, __int16 iTileTargetX, __int16 iTileTargetY)
 GAMECALL(0x402C25, int, __cdecl, CityToolMenuAction, int iMouseKeys, POINT pt)
+GAMECALL(0x402CF2, BOOL, __thiscall, CSimcityAppSetGameCursor, DWORD pThis, int iNewCursor, BOOL bActive)
 GAMECALL(0x402F9A, int, __thiscall, GetScreenAreaInfo, DWORD pThis, LPRECT lpRect)
 GAMECALL(0x480140, void, __stdcall, LoadSoundBuffer, int iSoundID, void* pBuffer)
 GAMECALL(0x48A810, DWORD, __cdecl, Direct_MovieCheck, char *sMovStr)
@@ -988,6 +989,7 @@ GAMECALL(0x402B3F, __int16, __stdcall, RandomWordLFSRMod128, int seed)
 
 GAMEOFF_PTR(void, pCWinAppThis,				0x4C7010)
 GAMEOFF(void*,	pCWndRootWindow,			0x4C702C)		// CMainFrame
+GAMEOFF(DWORD,	dwCursorGameHit,			0x4C70EC)
 GAMEOFF(BOOL,	bPriscillaActivated,		0x4C7104)
 GAMEOFF(DWORD*, dwAudioHandle,				0x4C7158)		// Various checks have pointed towards audio (sound and/or midi - perhaps stoppage given some context elsewhere)
 GAMEOFF(BOOL,	bOptionsMusicEnabled,		0x4C71F0)

--- a/modules/status_dialog.cpp
+++ b/modules/status_dialog.cpp
@@ -172,6 +172,11 @@ BOOL CALLBACK StatusDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM
 		// by Windows not the one that's currently active in the game.
 		SendMessage(hwndDlg, WM_SYSCOMMAND, (SC_MOVE | HTCAPTION), 0);
 		return FALSE;
+
+	case WM_SETCURSOR:
+		Game_CSimcityAppSetGameCursor((DWORD)&pCWinAppThis, 0, 0);
+		dwCursorGameHit = 4;
+		return 1;
 	}
 
 	return FALSE;


### PR DESCRIPTION
1) Add back the horizontal resolution check during cursor loading - this will determine which sized resources should be loaded.
2) Handle the WM_SETCURSOR message to unset the cursor while it is within the borders of the status dialogue.