### PR TITLE
Store the last city/tileset paths during load/save - R9

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -258,7 +258,6 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 		if (dwDetectedVersion == SC2KVERSION_DEMO)
 			gamePrimaryKey = "SimCity 2000 Win95 Demo";
 
-
 		// Registry check
 		int iInstallCheck;
 
@@ -267,6 +266,11 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 			ConsoleLog(LOG_INFO, "CORE: Portable entries created by faux-installer.");
 		else if (iInstallCheck == 1)
 			ConsoleLog(LOG_INFO, "CORE: Registry entries migrated by faux-installer.");
+
+		if (dwDetectedVersion == SC2KVERSION_1996) {
+			ConsoleLog(LOG_INFO, "CORE: Loading last stored load/save city and load tileset paths.");
+			LoadStoredPaths();
+		}
 
 		// Check for updates
 		if (bSettingsCheckForUpdates) {
@@ -390,6 +394,11 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 	case DLL_PROCESS_DETACH:
 		// Shut down the music thread
 		PostThreadMessage(dwMusicThreadID, WM_QUIT, NULL, NULL);
+
+		// Only save the stored paths during a graceful exit. (SC2K1996 only for now)
+		if (!bGameDead)
+			if (dwDetectedVersion == SC2KVERSION_1996)
+				SaveStoredPaths();
 
 		// Send a closing message and close the log file
 		ReleaseSMKFuncs();

--- a/hooks/hook_sc2k1996_miscellaneous.cpp
+++ b/hooks/hook_sc2k1996_miscellaneous.cpp
@@ -292,7 +292,11 @@ extern "C" int __stdcall Hook_FileDialogDoModal() {
 	HWND hWndOwner;
 	bool bIsReserved;
 	int iRet;
+	int nPathLen, nFileLen, nNewLen;
+	char szPath[MAX_PATH + 1];
 	OPENFILENAMEA* pOfn;
+
+	memset(szPath, 0, sizeof(szPath));
 
 	ToggleFloatingStatusDialog(FALSE);
 
@@ -300,13 +304,32 @@ extern "C" int __stdcall Hook_FileDialogDoModal() {
 	bIsReserved = pThis[36] == 0;
 	pThis[18] = (DWORD)hWndOwner;
 	pOfn = (OPENFILENAMEA*)(pThis + 17);
+
 	if (bIsReserved)
 		iRet = H_GetSaveFileNameA(pOfn);
 	else
 		iRet = H_GetLoadFileNameA(pOfn);
 	H_DialogPostModal(pThis);
 	if (!iRet)
-		iRet = 2;
+		iRet = IDCANCEL;
+
+	if (iRet != IDCANCEL) {
+		nPathLen = strlen(pOfn->lpstrFile);
+		nFileLen = strlen(pOfn->lpstrFileTitle);
+		if (nPathLen > 0 && nFileLen > 0) {
+			nNewLen = nPathLen - nFileLen;
+			if (nNewLen > 0) {
+				strncpy_s(szPath, sizeof(szPath)-1, pOfn->lpstrFile, nNewLen);
+				if (L_IsPathValid(szPath)) {
+					if ((DWORD)_ReturnAddress() == 0x42EB82 ||
+						(DWORD)_ReturnAddress() == 0x42FDCE) // From 'LoadCity' or 'SaveCityAs'
+						strcpy_s(szLastStoredCityPath, sizeof(szLastStoredCityPath) - 1, szPath);
+					else if ((DWORD)_ReturnAddress() == 0x42F312) // From 'LoadTileSet'
+						strcpy_s(szLastStoredTileSetPath, sizeof(szLastStoredTileSetPath) - 1, szPath);
+				}
+			}
+		}
+	}
 
 	ToggleFloatingStatusDialog(TRUE);
 

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -180,6 +180,7 @@ extern int iForcedBits;
 
 // Path adjustment (from registry_pathing area)
 
+BOOL L_IsPathValid(const char *pStr);
 const char *AdjustSource(char *buf, const char *path);
 
 // Utility functions
@@ -208,6 +209,8 @@ void DecodeDWORDArray(DWORD* dwArray, json::JSON jsonArray, size_t iCount, BOOL 
 LONG WINAPI CrashHandler(LPEXCEPTION_POINTERS lpExceptions);
 BOOL CALLBACK InstallDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam);
 BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam);
+void LoadStoredPaths();
+void SaveStoredPaths();
 int DoRegistryCheckAndInstall(void);
 void SetGamePath(void);
 const char *GetIniPath();
@@ -242,6 +245,9 @@ BOOL ConsoleCmdSetDebug(const char* szCommand, const char* szArguments);
 BOOL ConsoleCmdSetTile(const char* szCommand, const char* szArguments);
 
 extern const char *gamePrimaryKey;
+
+extern char szLastStoredCityPath[MAX_PATH + 1];
+extern char szLastStoredTileSetPath[MAX_PATH + 1];
 
 extern BOOL bGameDead;
 extern HMODULE hRealWinMM;


### PR DESCRIPTION
The paths are saved in the sc2kfix.ini and re-used during subsequent load/save calls.

The stored paths:
 - CityPath
 - TileSetPath

The CityPath that's stored is used for both load and save city calls at this point.