### PR TITLE
Class alignment changes and clarification

### DIFF
--- a/hooks/hook_animation.cpp
+++ b/hooks/hook_animation.cpp
@@ -21,8 +21,6 @@ extern "C" void __cdecl Hook_ToggleColorCycling_SC2K1996(CMFC3XPalette *pPalette
 	WORD wSimSpeed;
 	DWORD dwTitleScreenAnimation;
 	int iProgramStep;
-	DWORD dwTBControlsDisabled;
-	DWORD dwTBToolBarTitleDrag;
 	BOOL bCityViewAnim;
 
 	// Only redraw the relevant windows during:
@@ -44,11 +42,6 @@ extern "C" void __cdecl Hook_ToggleColorCycling_SC2K1996(CMFC3XPalette *pPalette
 					pMapToolBar = &pMainFrm->dwMFMapToolBar;
 					pCityToolBar = &pMainFrm->dwMFCityToolBar;
 
-					// For the toolbars, they're using vars from the parent MyToolBar class
-					// 46 and 47 are dwMyTBControlsDisabled and dwMyTBToolBarTitleDrag respectively.
-					dwTBControlsDisabled = pMapToolBar->dwMyTBControlsDisabled;
-					dwTBToolBarTitleDrag = pCityToolBar->dwMyTBToolBarTitleDrag;
-
 					// With this check, the redraw calls won't be made if either toolbar is being dragged.
 					// This avoids any bleeding that may occur as a result of the blitted border that will
 					// appear during this time.
@@ -59,10 +52,10 @@ extern "C" void __cdecl Hook_ToggleColorCycling_SC2K1996(CMFC3XPalette *pPalette
 					//       dragging case).
 					bCityViewAnim = TRUE;
 
-					if (pCityToolBar && dwTBToolBarTitleDrag)
+					if (pCityToolBar && pCityToolBar->dwCTBToolBarTitleDrag)
 						bCityViewAnim = FALSE;
 					
-					if (pMapToolBar && dwTBControlsDisabled)
+					if (pMapToolBar && pMapToolBar->dwMTBToolBarTitleDrag)
 						bCityViewAnim = FALSE;
 
 					if (CanUseFloatingStatusDialog() && bStatusDialogMoving)
@@ -91,8 +84,6 @@ extern "C" void __cdecl Hook_ToggleColorCycling_SC2K1995(CMFC3XPalette *pPalette
 	WORD wSimSpeed;
 	DWORD dwTitleScreenAnimation;
 	int iProgramStep;
-	DWORD dwTBControlsDisabled;
-	DWORD dwTBToolBarTitleDrag;
 	BOOL bCityViewAnim;
 
 	CSimcityAppPrimary &pCSimcityAppThis1995 = *(CSimcityAppPrimary *)0x4C6010;
@@ -115,11 +106,6 @@ extern "C" void __cdecl Hook_ToggleColorCycling_SC2K1995(CMFC3XPalette *pPalette
 					pMapToolBar = &pMainFrm->dwMFMapToolBar;
 					pCityToolBar = &pMainFrm->dwMFCityToolBar;
 
-					// For the toolbars, they're using vars from the parent MyToolBar class
-					// 46 and 47 are dwMyTBControlsDisabled and dwMyTBToolBarTitleDrag respectively.
-					dwTBControlsDisabled = pMapToolBar->dwMyTBControlsDisabled;
-					dwTBToolBarTitleDrag = pCityToolBar->dwMyTBToolBarTitleDrag;
-
 					// With this check, the redraw calls won't be made if either toolbar is being dragged.
 					// This avoids any bleeding that may occur as a result of the blitted border that will
 					// appear during this time.
@@ -130,10 +116,10 @@ extern "C" void __cdecl Hook_ToggleColorCycling_SC2K1995(CMFC3XPalette *pPalette
 					//       dragging case).
 					bCityViewAnim = TRUE;
 
-					if (pCityToolBar && dwTBToolBarTitleDrag)
+					if (pCityToolBar && pCityToolBar->dwCTBToolBarTitleDrag)
 						bCityViewAnim = FALSE;
 
-					if (pMapToolBar && dwTBControlsDisabled)
+					if (pMapToolBar && pMapToolBar->dwMTBToolBarTitleDrag)
 						bCityViewAnim = FALSE;
 
 					// CMainFrame m_hWnd - only call this specific redraw function before CSimcityView has been created.
@@ -159,8 +145,6 @@ extern "C" void __cdecl Hook_ToggleColorCycling_SC2KDemo(CMFC3XPalette *pPalette
 	WORD wSimSpeed;
 	DWORD dwTitleScreenAnimation;
 	int iProgramStep;
-	DWORD dwTBControlsDisabled;
-	DWORD dwTBToolBarTitleDrag;
 	BOOL bCityViewAnim;
 
 	CSimcityAppDemo &pCSimcityAppThisDemo = *(CSimcityAppDemo *)0x4B6A70;
@@ -183,11 +167,6 @@ extern "C" void __cdecl Hook_ToggleColorCycling_SC2KDemo(CMFC3XPalette *pPalette
 					pMapToolBar = &pMainFrm->dwMFMapToolBar;
 					pCityToolBar = &pMainFrm->dwMFCityToolBar;
 
-					// For the toolbars, they're using vars from the parent MyToolBar class
-					// 46 and 47 are dwMyTBControlsDisabled and dwMyTBToolBarTitleDrag respectively.
-					dwTBControlsDisabled = pMapToolBar->dwMyTBControlsDisabled;
-					dwTBToolBarTitleDrag = pCityToolBar->dwMyTBToolBarTitleDrag;
-
 					// With this check, the redraw calls won't be made if either toolbar is being dragged.
 					// This avoids any bleeding that may occur as a result of the blitted border that will
 					// appear during this time.
@@ -198,10 +177,10 @@ extern "C" void __cdecl Hook_ToggleColorCycling_SC2KDemo(CMFC3XPalette *pPalette
 					//       dragging case).
 					bCityViewAnim = TRUE;
 
-					if (pCityToolBar && dwTBToolBarTitleDrag)
+					if (pCityToolBar && pCityToolBar->dwCTBToolBarTitleDrag)
 						bCityViewAnim = FALSE;
 
-					if (pMapToolBar && dwTBControlsDisabled)
+					if (pMapToolBar && pMapToolBar->dwMTBToolBarTitleDrag)
 						bCityViewAnim = FALSE;
 
 					// CMainFrame m_hWnd - only call this specific redraw function before CSimcityView has been created.

--- a/hooks/hook_toolbars.cpp
+++ b/hooks/hook_toolbars.cpp
@@ -176,17 +176,16 @@ extern "C" void __stdcall Hook_CityToolBar_OnLButtonDown(UINT nFlags, CMFC3XPoin
 		}
 	}
 	else {
-		// Yes.. it is unfortunately like this.. alignment headaches.
 		pSCApp->dwSCADragSuspendSim = 1;
-		pThis->dwMyTBToolBarTitleDrag = 1;
-		pThis->dwMyTBPointOne.y = pt.x;
-		pThis->dwMyTBPointTwo.x = pt.y;
+		pThis->dwCTBToolBarTitleDrag = 1;
+		pThis->CTBGrabPoint.x = pt.x;
+		pThis->CTBGrabPoint.y = pt.y;
 		mainhWnd = SetCapture(pThis->m_hWnd);
 		GameMain_Wnd_FromHandle(mainhWnd);
 		ClientToScreen(pThis->m_hWnd, &pt);
 		Game_CityToolBar_MoveAndBlitToolBar(pThis, pt.x, pt.y);
-		pThis->dwMyTBPointTwo.y = pt.x;
-		pThis->dwCTBPointThree.x = pt.y;
+		pThis->CTBBorderPoint.x = pt.x;
+		pThis->CTBBorderPoint.y = pt.y;
 	}
 	dwCityToolBarArcologyDialogCancel = 0;
 }
@@ -438,15 +437,15 @@ extern "C" void __stdcall Hook_MapToolBar_OnLButtonDown(UINT nFlags, CMFC3XPoint
 		}
 	}
 	else {
-		pThis->dwMyTBControlsDisabled = 1;
-		pThis->dwMyTBPointOne.x = pt.x;
-		pThis->dwMyTBPointOne.y = pt.y;
+		pThis->dwMTBToolBarTitleDrag = 1;
+		pThis->MTBGrabPoint.x = pt.x;
+		pThis->MTBGrabPoint.y = pt.y;
 		mainhWnd = SetCapture(pThis->m_hWnd);
 		GameMain_Wnd_FromHandle(mainhWnd);
 		ClientToScreen(pThis->m_hWnd, &pt);
 		Game_MapToolBar_MoveAndBlitToolBar(pThis, pt.x, pt.y);
-		pThis->dwMyTBPointTwo.x = pt.x;
-		pThis->dwMyTBPointTwo.y = pt.y;
+		pThis->MTBBorderPoint.x = pt.x;
+		pThis->MTBBorderPoint.y = pt.y;
 	}
 }
 

--- a/include/sc2kclasses.h
+++ b/include/sc2kclasses.h
@@ -214,7 +214,7 @@ class CMyToolBar : public CMFC3XControlBar {
 public:
 	int iMyTBMenuButtonPos;
 	int iMyTBLastButtonPos;
-	CMFC3XPoint dwMyTBPointFour;
+	CMFC3XPoint MyTBMaxButtonHitPoint;
 	DWORD dwMyTBButtonMenu;
 	CGraphics *cGMyTBCGraphicsNormal;
 	CGraphics *cGMyTBCGraphicsDisabled;
@@ -229,17 +229,18 @@ public:
 	DWORD dwMyTBWindowFrame;
 	DWORD dwMyTBseventeen;
 	DWORD dwMyTBeighteen;
-	CMFC3XPoint dwMyTBPointThree;
-	DWORD dwMyTBControlsDisabled;
-	DWORD dwMyTBToolBarTitleDrag;
-	tagPOINT dwMyTBPointOne;
-	tagPOINT dwMyTBPointTwo;
+	CMFC3XPoint MyTBToolBarShapePt;
 };
 
 class CCityToolBar : public CMyToolBar {
 public:
-	tagPOINT dwCTBPointThree;
-	CMainFrame *dwCTBMainFrame;
+	DWORD dwCTBControlsDisabled;
+	DWORD dwCTBToolBarTitleDrag;
+	DWORD dwCTBOne;
+	CMFC3XPoint CTBGrabPoint;
+	CMFC3XPoint CTBBorderPoint;
+	DWORD dwCTBTwo;
+	CMainFrame *pCTBMainFrame;
 	DWORD dwCTBcxRightBorder;
 	DWORD dwCTBthirtyone;
 	CMFC3XMenu dwCTBMenuOne;
@@ -258,8 +259,12 @@ public:
 
 class CMapToolBar : public CMyToolBar {
 public:
+	DWORD dwMTBToolBarTitleDrag;
+	DWORD dwMTBControlsDisabled;
+	CMFC3XPoint MTBGrabPoint;
+	CMFC3XPoint MTBBorderPoint;
 	DWORD dwMTBTwentyNine;
-	CMainFrame *dwMTBMainFrame;
+	CMainFrame *pMTBMainFrame;
 	DWORD dwMTBcxRightBorder;
 };
 
@@ -338,35 +343,33 @@ public:
 #pragma pack(push, 1)
 class CSimcityView : public CMFC3XView {
 public:
-	CGraphics *dwSCVCGraphics;
+	CGraphics *SCVGraphics;
 	DWORD bSCVViewActive;
 	void *dwSCVThree;
-	void *dwSCVLockDIBRes;
-	LONG dwSCVWidth;
-	LONG dwSCVHeight;
-	CMFC3XScrollBar *dwSCVScrollBarVert;
-	CMFC3XScrollBar *dwSCVScrollBarHorz;
-	CMFC3XStatic *dwSCVStaticOne;
-	CMFC3XRect dwSCVScrollBarVertRectOne;
-	CMFC3XRect dwSCVScrollBarVertRectTwo;
-	CMFC3XRect dwSCVScrollBarVertRectThree;
-	CMFC3XRect dwSCVScrollPosVertRect;
-	CMFC3XRect dwSCVScrollBarHorzRectOne;
-	CMFC3XRect dwSCVScrollBarHorzRectTwo;
-	CMFC3XRect dwSCVScrollBarHorzRectThree;
-	CMFC3XRect dwSCVScrollPosHorzRect;
-	CMFC3XRect dwSCVScrollPosRect;
-	CMFC3XRect dwSCVStaticRect;
+	void *pSCVGraphicLockDIBRes;
+	LONG dwSCVGraphicWidth;
+	LONG dwSCVGraphicHeight;
+	CMFC3XScrollBar *SCVScrollBarVert;
+	CMFC3XScrollBar *SCVScrollBarHorz;
+	CMFC3XStatic *SCVStaticOne;
+	CMFC3XRect SCVScrollBarVertRectOne;
+	CMFC3XRect SCVScrollBarVertRectTwo;
+	CMFC3XRect SCVScrollBarVertRectThree;
+	CMFC3XRect SCVScrollPosVertRect;
+	CMFC3XRect SCVScrollBarHorzRectOne;
+	CMFC3XRect SCVScrollBarHorzRectTwo;
+	CMFC3XRect SCVScrollBarHorzRectThree;
+	CMFC3XRect SCVScrollPosHorzRect;
+	CMFC3XRect SCVScrollPosRect;
+	CMFC3XRect SCVStaticRect;
 	DWORD dwSCVLeftMouseButtonDown;
 	DWORD dwSCVLeftMouseDownInGameArea;
 	DWORD dwSCVCursorInGameArea;
-	CMFC3XPoint dwSCVMousePoint;
+	CMFC3XPoint SCVMousePoint;
 	DWORD dwSCVRightClickMenuOpen;
-	CMFC3XPoint dwSCVRealPoint;
+	CMFC3XPoint SCVRealPoint;
 	DWORD dwSCVSixtyOne[6];
-	int iSCVAreaViewWidth;
-	int iSCVAreaViewHeight;
-	CMFC3XPoint dwSCVAdjustedPoint;
+	CMFC3XRect SCVAreaView;
 	WORD wSCVZoomLevel;
 	DWORD dwSCVIsZoomed;
 };


### PR DESCRIPTION
Adjusted variable alignment when it comes to CMyToolBar -> CCityToolBar/CMapToolBar; clarified the variable names to ascribe better meaning.

Another tweak in the main game view class to account for the SCVAreaView rect.