### PR TITLE
Settings dialog tweaks

### DIFF
--- a/modules/settings.cpp
+++ b/modules/settings.cpp
@@ -349,7 +349,9 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 			"after which a new song will be selected when the game window regains focus.");
 		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SOUND_REPLACEMENTS),
 			"Certain versions of SimCity 2000 had higher quality sounds than the Windows 95 versions. "
-			"This setting controls whether or not SimCity 2000 plays higher quality versions of various sounds for which said higher quality versions exist.");
+			"This setting controls whether or not SimCity 2000 plays higher quality versions of various sounds for which said higher quality versions exist.\n\n"
+
+			"Enabling or disabling this setting takes effect after restarting the game.");
 		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SHUFFLE_MUSIC),
 			"By default, SimCity 2000 selects \"random\" music by playing the next track in a looping playlist of songs. "
 			"This setting controls whether or not to shuffle the playlist when the game starts and when the end of the playlist is reached.");
@@ -366,7 +368,9 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 
 			"Enabling or disabling this setting takes effect after restarting the game.");
 		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_CHECK_FOR_UPDATES),
-			"This setting checks to see if there's a newer release of sc2kfix available when the game starts.\n\n");
+			"This setting checks to see if there's a newer release of sc2kfix available when the game starts.\n\n"
+
+			"Enabling or disabling this setting takes effect after restarting the game.");
 		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_DONT_LOAD_MODS),
 			"Enabling this setting forces sc2kfix to skip loading any installed mods on startup.\n\n"
 

--- a/sc2kfix.rc
+++ b/sc2kfix.rc
@@ -104,7 +104,6 @@ END
 
 IDD_SETTINGS DIALOGEX 0, 0, 299, 434
 STYLE DS_SETFONT | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
-EXSTYLE WS_EX_TOPMOST
 CAPTION "sc2kfix Settings"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
@@ -121,7 +120,7 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,184,268,10
     CONTROL         " Use grammar-corrected and disambiguated dialog strings (Default: on)",IDC_SETTINGS_CHECK_NEW_STRINGS,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,306,268,10
-    CONTROL         " Use higher quality sounds (Default: on)",IDC_SETTINGS_CHECK_SOUND_REPLACEMENTS,
+    CONTROL         " * Use higher quality sounds (Default: on)",IDC_SETTINGS_CHECK_SOUND_REPLACEMENTS,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,229,268,10
     CONTROL         " Shuffle music instead of looping predefined playlist (Default: off)",IDC_SETTINGS_CHECK_SHUFFLE_MUSIC,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,214,268,10


### PR DESCRIPTION
1) Tooltip tweaks for a couple of settings that require program restarts.
2) "Use higher quality sounds" label adjusted to also denote a restart being required.
3) WS_EX_TOPMOST extended style removed.