### PR TITLE
Reimplement console to be more Junos-like

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -207,6 +207,8 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 						bDisableFixedTiles = TRUE;
 					if (!lstrcmpiW(argv[i], L"-experiment=tripgenerator"))
 						dwExperimentsEnabled |= EXPERIMENT_TRIPGENERATOR;
+					if (!lstrcmpiW(argv[i], L"-experiment=newconsole"))
+						dwExperimentsEnabled |= EXPERIMENT_NEWCONSOLE;
 					if (!lstrcmpiW(argv[i], L"-experiment=all"))
 						dwExperimentsEnabled = EXPERIMENT_EVERYTHING;
 					if (!lstrcmpiW(argv[i], L"-bitmode"))
@@ -539,7 +541,11 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 		// Start the console thread.
 		if (bConsoleEnabled) {
 			ConsoleLog(LOG_INFO, "CORE: Starting console thread.\n");
-			hConsoleThread = CreateThread(NULL, 0, ConsoleThread, 0, 0, NULL);
+			if (dwExperimentsEnabled & EXPERIMENT_NEWCONSOLE) {
+				ConsoleLog(LOG_INFO, "CORE: EXPERIMENT_NEWCONSOLE enabled.\n");
+				hConsoleThread = CreateThread(NULL, 0, NewConsoleThread, 0, 0, NULL);
+			} else
+				hConsoleThread = CreateThread(NULL, 0, ConsoleThread, 0, 0, NULL);
 		}
 
 		// Set up the modding infrastructure for the 1996 Special Edition version.

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -207,8 +207,6 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 						bDisableFixedTiles = TRUE;
 					if (!lstrcmpiW(argv[i], L"-experiment=tripgenerator"))
 						dwExperimentsEnabled |= EXPERIMENT_TRIPGENERATOR;
-					if (!lstrcmpiW(argv[i], L"-experiment=newconsole"))
-						dwExperimentsEnabled |= EXPERIMENT_NEWCONSOLE;
 					if (!lstrcmpiW(argv[i], L"-experiment=all"))
 						dwExperimentsEnabled = EXPERIMENT_EVERYTHING;
 					if (!lstrcmpiW(argv[i], L"-bitmode"))
@@ -309,8 +307,8 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 		// Dump some console opening info
 		if (bConsoleEnabled) {
 			ConsoleLog(LOG_INFO, "CORE: Spawned console session.\n");
-			printf(VT100_COLOUR_CYAN "[INFO ]" VT100_DEFAULT " CORE: ");
-			ConsoleCmdShowDebug(NULL, NULL);
+			// printf(VT100_COLOUR_CYAN "[INFO ]" VT100_DEFAULT " CORE: ");
+			// ConsoleCmdShowDebug(NULL, NULL);
 		}
 
 		// Load the FluidSynth library in case we need it
@@ -541,11 +539,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 		// Start the console thread.
 		if (bConsoleEnabled) {
 			ConsoleLog(LOG_INFO, "CORE: Starting console thread.\n");
-			if (dwExperimentsEnabled & EXPERIMENT_NEWCONSOLE) {
-				ConsoleLog(LOG_INFO, "CORE: EXPERIMENT_NEWCONSOLE enabled.\n");
-				hConsoleThread = CreateThread(NULL, 0, NewConsoleThread, 0, 0, NULL);
-			} else
-				hConsoleThread = CreateThread(NULL, 0, ConsoleThread, 0, 0, NULL);
+			hConsoleThread = CreateThread(NULL, 0, NewConsoleThread, 0, 0, NULL);
 		}
 
 		// Set up the modding infrastructure for the 1996 Special Edition version.

--- a/include/commandtree.hpp
+++ b/include/commandtree.hpp
@@ -178,7 +178,7 @@ namespace console {
 
 		ConsoleCommand ToCommand(bool& ok) const {
 			ok = (Type == Class::Command);
-			return ok ? std::move(*Internal.Command) : ConsoleCommand();
+			return ok ? *Internal.Command : ConsoleCommand();
 		}
 
 		JSONWrapper<map<string, CommandTree>> ObjectRange() {

--- a/include/commandtree.hpp
+++ b/include/commandtree.hpp
@@ -9,12 +9,33 @@
 #include <string>
 #include <deque>
 #include <map>
+#include <vector>
 #include <type_traits>
 #include <initializer_list>
 #include <ostream>
 #include <iostream>
 
+#ifdef SC2KFIX_CORE
 #include <sc2kfix.h>
+#else
+#ifndef command_proc_t
+typedef bool (*command_proc_t)(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam);
+#endif
+#ifndef COMMAND_OPTPARAM_NONE
+#define COMMAND_OPTPARAM_NONE 0
+#endif
+#ifndef ConsoleCommand
+class ConsoleCommand {
+public:
+	ConsoleCommand() { iType = 0; pCommand = NULL; szDescription = "(description not set)"; iOptParam = COMMAND_OPTPARAM_NONE; }
+	ConsoleCommand(int i, command_proc_t p, const char* s = "(description not set)", intptr_t o = COMMAND_OPTPARAM_NONE) { iType = i; pCommand = p; szDescription = s; iOptParam = o; }
+	int iType;
+	command_proc_t pCommand;
+	const char* szDescription;
+	intptr_t iOptParam;
+};
+#endif
+#endif
 
 // Variant of json::JSON specifically for console command trees
 std::string string_format(const char* fmt, ...);

--- a/include/commandtree.hpp
+++ b/include/commandtree.hpp
@@ -194,7 +194,7 @@ namespace console {
 
 		ConsoleCommand ToCommand() const {
 			bool b;
-			return std::move(ToCommand(b));
+			return ToCommand(b);
 		}
 
 		ConsoleCommand ToCommand(bool& ok) const {

--- a/include/commandtree.hpp
+++ b/include/commandtree.hpp
@@ -1,0 +1,282 @@
+// sc2kfix include/commandtree.hpp: variant of json.hpp for the console command tree
+// (c) 2025-2026 sc2kfix project (https://sc2kfix.net) - released under the MIT license
+
+#pragma once
+
+#include <cstdint>
+#include <cmath>
+#include <cctype>
+#include <string>
+#include <deque>
+#include <map>
+#include <type_traits>
+#include <initializer_list>
+#include <ostream>
+#include <iostream>
+
+#include <sc2kfix.h>
+
+// Variant of json::JSON specifically for console command trees
+std::string string_format(const char* fmt, ...);
+
+namespace console {
+	using std::map;
+	using std::string;
+	using std::enable_if;
+	using std::initializer_list;
+	using std::is_same;
+	using std::is_convertible;
+	using std::is_integral;
+	using std::is_floating_point;
+	using std::is_pointer;
+
+	class CommandTree {
+		union BackingData {
+			BackingData(ConsoleCommand p) : Command(new ConsoleCommand(p)) {}
+			BackingData() : Command() {}
+
+			map<string, CommandTree>* Map;
+			ConsoleCommand* Command;
+		} Internal;
+
+	public:
+		enum class Class {
+			Null,
+			Object,
+			Command
+		};
+
+		template<typename Container> class JSONWrapper {
+			Container* object;
+
+		public:
+			JSONWrapper(Container* val) : object(val) {}
+			JSONWrapper(std::nullptr_t) : object(nullptr) {}
+
+			typename Container::iterator begin() { return object ? object->begin() : typename Container::iterator(); }
+			typename Container::iterator end() { return object ? object->end() : typename Container::iterator(); }
+			typename Container::const_iterator begin() const { return object ? object->begin() : typename Container::iterator(); }
+			typename Container::const_iterator end() const { return object ? object->end() : typename Container::iterator(); }
+		};
+
+		template <typename Container> class JSONConstWrapper {
+			const Container* object;
+
+		public:
+			JSONConstWrapper(const Container* val) : object(val) {}
+			JSONConstWrapper(std::nullptr_t) : object(nullptr) {}
+
+			typename Container::const_iterator begin() const { return object ? object->begin() : typename Container::const_iterator(); }
+			typename Container::const_iterator end() const { return object ? object->end() : typename Container::const_iterator(); }
+		};
+
+		CommandTree() : Internal(), Type(Class::Null) {}
+
+		CommandTree(CommandTree&& other) noexcept : Internal(other.Internal), Type(other.Type) {
+			other.Type = Class::Null;
+			other.Internal.Map = nullptr;
+		}
+
+		CommandTree& operator=(CommandTree&& other) noexcept {
+			ClearInternal();
+			Internal = other.Internal;
+			Type = other.Type;
+			other.Internal.Map = nullptr;
+			other.Type = Class::Null;
+			return *this;
+		}
+
+		CommandTree(const CommandTree& other) {
+			switch (other.Type) {
+			case Class::Object:
+				Internal.Map = new map<string, CommandTree>(other.Internal.Map->begin(), other.Internal.Map->end());
+				break;
+			case Class::Command:
+				Internal.Command = new ConsoleCommand(*other.Internal.Command);
+				break;
+			default:
+				Internal = other.Internal;
+			}
+			Type = other.Type;
+		}
+
+		CommandTree& operator=(const CommandTree& other) {
+			ClearInternal();
+			switch (other.Type) {
+			case Class::Object:
+				Internal.Map = new map<string, CommandTree>(other.Internal.Map->begin(), other.Internal.Map->end());
+				break;
+			case Class::Command:
+				Internal.Command = new ConsoleCommand(*other.Internal.Command);
+				break;
+			default:
+				Internal = other.Internal;
+			}
+			Type = other.Type;
+			return *this;
+		}
+
+		~CommandTree() {
+			switch (Type) {
+			case Class::Object:
+				delete Internal.Map;
+				break;
+			case Class::Command:
+				delete Internal.Command;
+				break;
+			default:;
+			}
+		}
+
+		CommandTree(ConsoleCommand) : Internal(), Type(Class::Command) {}
+
+		CommandTree(std::nullptr_t) : Internal(), Type(Class::Null) {}
+
+		static CommandTree Make(Class type) {
+			CommandTree ret; ret.SetType(type);
+			return ret;
+		}
+
+		CommandTree& operator=(ConsoleCommand c) {
+			SetType(Class::Command); *Internal.Command = ConsoleCommand(c);
+			return *this;
+		}
+
+		CommandTree& operator[](const string& key) {
+			SetType(Class::Object); return Internal.Map->operator[](key);
+		}
+
+		CommandTree& at(const string& key) {
+			return operator[](key);
+		}
+
+		const CommandTree& at(const string& key) const {
+			return Internal.Map->at(key);
+		}
+
+		bool hasKey(const string& key) const {
+			if (Type == Class::Object)
+				return Internal.Map->find(key) != Internal.Map->end();
+			return false;
+		}
+
+		int size() const {
+			if (Type == Class::Object)
+				return Internal.Map->size();
+			return -1;
+		}
+
+		Class ObjectType() const { return Type; }
+
+		/// Functions for getting primitives from the CommandTree object.
+		bool IsNull() const { return Type == Class::Null; }
+
+		ConsoleCommand ToCommand() const {
+			bool b;
+			return std::move(ToCommand(b));
+		}
+
+		ConsoleCommand ToCommand(bool& ok) const {
+			ok = (Type == Class::Command);
+			return ok ? std::move(*Internal.Command) : ConsoleCommand();
+		}
+
+		JSONWrapper<map<string, CommandTree>> ObjectRange() {
+			if (Type == Class::Object)
+				return JSONWrapper<map<string, CommandTree>>(Internal.Map);
+			return JSONWrapper<map<string, CommandTree>>(nullptr);
+		}
+
+		JSONConstWrapper<map<string, CommandTree>> ObjectRange() const {
+			if (Type == Class::Object)
+				return JSONConstWrapper<map<string, CommandTree>>(Internal.Map);
+			return JSONConstWrapper<map<string, CommandTree>>(nullptr);
+		}
+
+		void merge(CommandTree jsonSource) {
+			for (auto& p : *jsonSource.Internal.Map) {
+				switch (p.second.Type) {
+				case Class::Object:
+					if (Internal.Map->operator[](p.first).IsNull())
+						Internal.Map->operator[](p.first) = p.second;
+					else
+						Internal.Map->operator[](p.first).merge(p.second);
+					break;
+				default:
+					Internal.Map->operator[](p.first) = p.second;
+					break;
+				}
+			}
+		}
+
+		string dump(int depth = 1, string tab = "  ") const {
+			string pad = "";
+			for (int i = 0; i < depth; ++i, pad += tab);
+
+			switch (Type) {
+			case Class::Null:
+				return "null";
+			case Class::Object: {
+				string s = "{\n";
+				bool skip = true;
+				for (auto& p : *Internal.Map) {
+					if (!skip) s += ",\n";
+					s += (pad + "\"" + p.first + "\" : " + p.second.dump(depth + 1, tab));
+					skip = false;
+				}
+				s += ("\n" + pad.erase(0, 2) + "}");
+				return s;
+			}
+			case Class::Command:
+				return string_format("{ %d, 0x%08X }", Internal.Command->iType, Internal.Command->pCommand);
+			default:
+				return "";
+			}
+			return "";
+		}
+
+	private:
+		void SetType(Class type) {
+			if (type == Type)
+				return;
+
+			ClearInternal();
+
+			switch (type) {
+			case Class::Null:
+				Internal.Map = nullptr;
+				break;
+			case Class::Object:
+				Internal.Map = new map<string, CommandTree>();
+				break;
+			case Class::Command:
+				Internal.Command = new ConsoleCommand();
+				break;
+			}
+
+			Type = type;
+		}
+
+	private:
+		/* beware: only call if YOU know that Internal is allocated. No checks performed here.
+		   This function should be called in a constructed CommandTree just before you are going to
+		  overwrite Internal...
+		*/
+		void ClearInternal() {
+			switch (Type) {
+			case Class::Object:
+				delete Internal.Map;
+				break;
+			case Class::Command:
+				delete Internal.Command;
+				break;
+			default:;
+			}
+		}
+
+	private:
+		Class Type = Class::Null;
+	};
+
+	CommandTree Object();
+}

--- a/include/json.hpp
+++ b/include/json.hpp
@@ -99,7 +99,7 @@ namespace json {
 		JSON(initializer_list<JSON> list) : JSON() {
 			SetType(Class::Object);
 			for (auto i = list.begin(), e = list.end(); i != e; ++i, ++i)
-				operator[](i->ToString()) = *std::next(i);
+				operator[](i->ToInternalString()) = *std::next(i);
 		}
 
 		JSON(JSON&& other) noexcept : Internal(other.Internal), Type(other.Type) {
@@ -265,13 +265,22 @@ namespace json {
 		/// Functions for getting primitives from the JSON object.
 		bool IsNull() const { return Type == Class::Null; }
 
+		string ToInternalString() const {
+			bool b; return std::move(ToInternalString(b));
+		}
+
+		string ToInternalString(bool& ok) const {
+			ok = (Type == Class::String);
+			return ok ? std::move(json_escape(*Internal.String)) : string("");
+		}
+
 		string ToString() const {
-			bool b; return std::move(ToString(b));
+			bool b; return ToString(b);
 		}
 
 		string ToString(bool& ok) const {
 			ok = (Type == Class::String);
-			return ok ? std::move(json_escape(*Internal.String)) : string("");
+			return ok ? *Internal.String : string("");
 		}
 
 		double ToFloat() const {

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -330,7 +330,7 @@ enum {
 // 
 // Generally starts with:
 //   if (iBreakoutState == BREAKOUT_QUESTION)
-//       bDontClearNextCommand = true;
+//       bConsoleKeepCommandBuffer = true;
 //   if (iBreakoutState != BREAKOUT_RETURN)
 //       return false;
 typedef bool (*command_proc_t)(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam);

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -303,11 +303,15 @@ enum {
 // New console stuff
 #define CTRL(c) (c - 64)
 
-#define COMMAND_TYPE_UNKNOWN		0		// undefined
-#define COMMAND_TYPE_BRANCH			1		// fake "command" used to add documentation to trees
-#define COMMAND_TYPE_DOCUMENTED		2		// command will show up in ? without set undoc
-#define COMMAND_TYPE_UNDOCUMENTED	3		// command requires set undoc to show up in ?
-#define COMMAND_TYPE_HIDDEN			4		// command does not show up in ? or autocomplete
+#define COMMAND_TYPE_UNKNOWN		0	// undefined
+#define COMMAND_TYPE_BRANCH			1	// fake "command" used to add documentation to trees
+#define COMMAND_TYPE_DOCUMENTED		2	// command will show up in ? without set undoc
+#define COMMAND_TYPE_UNDOCUMENTED	3	// command requires set undoc to show up in ?
+#define COMMAND_TYPE_HIDDEN			4	// command does not show up in ? or autocomplete
+
+#define COMMAND_OPTPARAM_NONE		0	// don't pass anything special in iOptParam (default)
+#define COMMAND_OPTPARAM_ROOTNAME	1	// pass a pointer to the entered root command name
+#define COMMAND_OPTPARAM_TREE		2	// pass a pointer to std::string vecSplit
 
 #define BREAKOUT_NONE		0
 #define BREAKOUT_RETURN		1
@@ -321,7 +325,8 @@ enum {
 // All arguments after the command are in `args`. The CLI parser breakout state that caused the
 // command to be invoked is in `iBreakoutState` (should usually only be BREAKOUT_QUESTION or
 // BREAKOUT_RETURN; others should generally be treated as a syntax error). iOptParam allows a
-// command that cascades into another command to pass data down the chain.
+// command that cascades into another command to pass data down the chain, and also allows for
+// the command parser to send extra data to the command if registered to do so.
 // 
 // Generally starts with:
 //   if (iBreakoutState == BREAKOUT_QUESTION)
@@ -332,8 +337,8 @@ typedef bool (*command_proc_t)(std::vector<std::string> args, int iBreakoutState
 
 class ConsoleCommand {
 public:
-	ConsoleCommand() { iType = 0; pCommand = NULL; szDescription = ""; iOptParam = 0; }
-	ConsoleCommand(int i, command_proc_t p, const char* s = "", intptr_t o = 0) { iType = i; pCommand = p; szDescription = s; iOptParam = o; }
+	ConsoleCommand() { iType = 0; pCommand = NULL; szDescription = "(description not set)"; iOptParam = COMMAND_OPTPARAM_NONE; }
+	ConsoleCommand(int i, command_proc_t p, const char* s = "(description not set)", intptr_t o = COMMAND_OPTPARAM_NONE) { iType = i; pCommand = p; szDescription = s; iOptParam = o; }
 	int iType;
 	command_proc_t pCommand;
 	const char* szDescription;

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -351,9 +351,9 @@ extern char szGamePath[MAX_PATH];
 
 // Settings globals
 
-extern json::JSON jsonSettingsCore;
-extern json::JSON jsonSettingsCoreWorkingCopy;
-extern json::JSON jsonSettingsMods;
+extern HOOKEXT_CPP json::JSON jsonSettingsCore;
+extern HOOKEXT_CPP json::JSON jsonSettingsCoreWorkingCopy;
+extern HOOKEXT_CPP json::JSON jsonSettingsMods;
 
 // No longer actually used for settings, but as temporary buffers
 extern char szSettingsMayorName[64];
@@ -409,6 +409,7 @@ HOOKEXT_CPP bool string_ends_with(std::string& str, const char* suffix);
 HOOKEXT_CPP bool string_contains(std::string& str, const char* substr);
 HOOKEXT_CPP std::string string_format(const char* fmt, ...);
 HOOKEXT_CPP bool string_split(std::string str, std::vector<std::string>& qargs);
+HOOKEXT_CPP void PrintAlignedStringMap(std::map<std::string, std::string> mapStr, int iPrefixSpaces = 3);
 
 // Globals etc.
 

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -104,6 +104,7 @@ template <typename T> std::string to_string_precision(const T value, const int p
 
 #define EXPERIMENT_NONE				0			// status: nice and safe
 #define EXPERIMENT_TRIPGENERATOR	1			// status: dubiously stable
+#define EXPERIMENT_NEWCONSOLE		2			// status: dubiously stable and uncommented
 #define EXPERIMENT_EVERYTHING		0xFFFFFFFF	// status: good luck and godspeed
 
 #define ListView_InsertItemType(hwndLV, i, tmask) {\
@@ -299,6 +300,44 @@ enum {
 	LOG_DEBUG
 };
 
+// New console stuff
+#define CTRL(c) (c - 64)
+
+#define COMMAND_TYPE_UNKNOWN		0		// undefined
+#define COMMAND_TYPE_BRANCH			1		// fake "command" used to add documentation to trees
+#define COMMAND_TYPE_DOCUMENTED		2		// command will show up in ? without set undoc
+#define COMMAND_TYPE_UNDOCUMENTED	3		// command requires set undoc to show up in ?
+#define COMMAND_TYPE_HIDDEN			4		// command does not show up in ? or autocomplete
+
+#define BREAKOUT_NONE		0
+#define BREAKOUT_RETURN		1
+#define BREAKOUT_TAB		2
+#define BREAKOUT_QUESTION	3
+#define BREAKOUT_INTERRUPT	4
+#define BREAKOUT_SPACE		5
+
+// command_proc_t: console command procedure typedef
+// Returns false if the parser should throw "invalid argument", true otherwise
+// All arguments after the command are in `args`. The CLI parser breakout state that caused the
+// command to be invoked is in `iBreakoutState` (should usually only be BREAKOUT_QUESTION or
+// BREAKOUT_RETURN; others should generally be treated as a syntax error)
+// 
+// Generally starts with:
+//   if (iBreakoutState == BREAKOUT_QUESTION)
+//       bDontClearNextCommand = true;
+//   if (iBreakoutState != BREAKOUT_RETURN)
+//       return false;
+typedef bool (*command_proc_t)(std::vector<std::string> args, int iBreakoutState);
+
+class ConsoleCommand {
+public:
+	ConsoleCommand() { iType = 0; pCommand = NULL; szDescription = ""; }
+	ConsoleCommand(int i, command_proc_t p, const char* s = "") { iType = i; pCommand = p; szDescription = s; }
+	int iType;
+	command_proc_t pCommand;
+	const char* szDescription;
+};
+
 // Game path global
 
 extern char szGamePath[MAX_PATH];
@@ -362,6 +401,7 @@ HOOKEXT_CPP bool string_starts_with(std::string& str, const char* prefix);
 HOOKEXT_CPP bool string_ends_with(std::string& str, const char* suffix);
 HOOKEXT_CPP bool string_contains(std::string& str, const char* substr);
 HOOKEXT_CPP std::string string_format(const char* fmt, ...);
+HOOKEXT_CPP bool string_split(std::string str, std::vector<std::string>& qargs);
 
 // Globals etc.
 
@@ -430,6 +470,8 @@ BOOL ConsoleCmdShowVersion(const char* szCommand, const char* szArguments);
 BOOL ConsoleCmdSet(const char* szCommand, const char* szArguments);
 BOOL ConsoleCmdSetDebug(const char* szCommand, const char* szArguments);
 BOOL ConsoleCmdSetTile(const char* szCommand, const char* szArguments);
+
+DWORD WINAPI NewConsoleThread(LPVOID lpParameter);
 
 void LoadNativeCodeMods(void);
 

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -320,22 +320,24 @@ enum {
 // Returns false if the parser should throw "invalid argument", true otherwise
 // All arguments after the command are in `args`. The CLI parser breakout state that caused the
 // command to be invoked is in `iBreakoutState` (should usually only be BREAKOUT_QUESTION or
-// BREAKOUT_RETURN; others should generally be treated as a syntax error)
+// BREAKOUT_RETURN; others should generally be treated as a syntax error). iOptParam allows a
+// command that cascades into another command to pass data down the chain.
 // 
 // Generally starts with:
 //   if (iBreakoutState == BREAKOUT_QUESTION)
 //       bDontClearNextCommand = true;
 //   if (iBreakoutState != BREAKOUT_RETURN)
 //       return false;
-typedef bool (*command_proc_t)(std::vector<std::string> args, int iBreakoutState);
+typedef bool (*command_proc_t)(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam);
 
 class ConsoleCommand {
 public:
-	ConsoleCommand() { iType = 0; pCommand = NULL; szDescription = ""; }
-	ConsoleCommand(int i, command_proc_t p, const char* s = "") { iType = i; pCommand = p; szDescription = s; }
+	ConsoleCommand() { iType = 0; pCommand = NULL; szDescription = ""; iOptParam = 0; }
+	ConsoleCommand(int i, command_proc_t p, const char* s = "", intptr_t o = 0) { iType = i; pCommand = p; szDescription = s; iOptParam = o; }
 	int iType;
 	command_proc_t pCommand;
 	const char* szDescription;
+	intptr_t iOptParam;
 };
 
 // Game path global

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -320,6 +320,11 @@ enum {
 #define BREAKOUT_INTERRUPT	4
 #define BREAKOUT_SPACE		5
 
+#define printf_red(s, ...) printf(VT100_COLOUR_RED s VT100_DEFAULT, __VA_ARGS__)
+#define printf_lightred(s, ...) printf(VT100_COLOUR_BRIGHT_RED s VT100_DEFAULT, __VA_ARGS__)
+#define printf_yellow(s, ...) printf(VT100_COLOUR_YELLOW s VT100_DEFAULT, __VA_ARGS__)
+#define printf_lightblue(s, ...) printf(VT100_COLOUR_BRIGHT_BLUE s VT100_DEFAULT, __VA_ARGS__)
+
 // command_proc_t: console command procedure typedef
 // Returns false if the parser should throw "invalid argument", true otherwise
 // All arguments after the command are in `args`. The CLI parser breakout state that caused the

--- a/mods/sc2kfix.h
+++ b/mods/sc2kfix.h
@@ -1,5 +1,5 @@
 // sc2kfix mods/sc2kfix.h: main include file for mods
-// (c) 2025 sc2kfix project (https://sc2kfix.net) - released under the MIT license
+// (c) 2025-2026 sc2kfix project (https://sc2kfix.net) - released under the MIT license
 
 #pragma once
 #pragma warning(disable : 4200)
@@ -16,6 +16,7 @@
 #include "../include/commonhelp.h"
 #include "../include/sc2kclasses.h"
 #include "../include/sc2k_1996.h"
+#include "../include/vt100.h"
 
 #define IFF_HEAD(a, b, c, d) ((DWORD)d << 24 | (DWORD)c << 16 | (DWORD)b << 8 | (DWORD)a)
 
@@ -88,6 +89,11 @@ typedef struct {
 #define BREAKOUT_QUESTION	3
 #define BREAKOUT_INTERRUPT	4
 #define BREAKOUT_SPACE		5
+
+#define printf_red(s, ...) printf(VT100_COLOUR_RED s VT100_DEFAULT, __VA_ARGS__)
+#define printf_lightred(s, ...) printf(VT100_COLOUR_BRIGHT_RED s VT100_DEFAULT, __VA_ARGS__)
+#define printf_yellow(s, ...) printf(VT100_COLOUR_YELLOW s VT100_DEFAULT, __VA_ARGS__)
+#define printf_lightblue(s, ...) printf(VT100_COLOUR_BRIGHT_BLUE s VT100_DEFAULT, __VA_ARGS__)
 
 #define HOOKS_COUNT(st) (sizeof(st) / sizeof(sc2kfix_mod_hook_t))
 

--- a/mods/sc2kfix.h
+++ b/mods/sc2kfix.h
@@ -11,6 +11,7 @@
 #define HOOKCB		extern "C" __declspec(dllexport)
 
 #include "../include/json.hpp"
+#include "../include/commandtree.hpp"
 #include "../include/mfc3xhelp.h"
 #include "../include/commonhelp.h"
 #include "../include/sc2kclasses.h"
@@ -69,8 +70,31 @@ typedef struct {
 	sc2kfix_mod_hook_t* pstHooks;		// Mandatory
 } sc2kfix_mod_info_t;
 
+#define CTRL(c) (c - 64)
+
+#define COMMAND_TYPE_UNKNOWN		0	// undefined
+#define COMMAND_TYPE_BRANCH			1	// fake "command" used to add documentation to trees
+#define COMMAND_TYPE_DOCUMENTED		2	// command will show up in ? without set undoc
+#define COMMAND_TYPE_UNDOCUMENTED	3	// command requires set undoc to show up in ?
+#define COMMAND_TYPE_HIDDEN			4	// command does not show up in ? or autocomplete
+
+#define COMMAND_OPTPARAM_NONE		0	// don't pass anything special in iOptParam (default)
+#define COMMAND_OPTPARAM_ROOTNAME	1	// pass a pointer to the entered root command name
+#define COMMAND_OPTPARAM_TREE		2	// pass a pointer to std::string vecSplit
+
+#define BREAKOUT_NONE		0
+#define BREAKOUT_RETURN		1
+#define BREAKOUT_TAB		2
+#define BREAKOUT_QUESTION	3
+#define BREAKOUT_INTERRUPT	4
+#define BREAKOUT_SPACE		5
 
 #define HOOKS_COUNT(st) (sizeof(st) / sizeof(sc2kfix_mod_hook_t))
+
+HOOKEXT bool bConsoleInLuaREPL;
+HOOKEXT bool bConsoleElevatedMode;
+HOOKEXT bool bConsoleKeepCommandBuffer;
+HOOKEXT_CPP console::CommandTree treeConsoleCommands;
 
 HOOKEXT void CenterDialogBox(HWND hwndDlg);
 HOOKEXT HWND CreateTooltip(HWND hDlg, HWND hControl, const char* szText);
@@ -88,3 +112,4 @@ HOOKEXT_CPP std::string Base64Encode(const unsigned char* pSrcData, size_t iSrcC
 HOOKEXT_CPP size_t Base64Decode(BYTE* pBuffer, size_t iBufSize, const unsigned char* pSrcData, size_t iSrcCount);
 HOOKEXT_CPP json::JSON EncodeDWORDArray(DWORD* dwArray, size_t iCount, BOOL bBigEndian);
 HOOKEXT_CPP void DecodeDWORDArray(DWORD* dwArray, json::JSON jsonArray, size_t iCount, BOOL bBigEndian);
+HOOKEXT_CPP void PrintAlignedStringMap(std::map<std::string, std::string> mapStr, int iPrefixSpaces = 3);

--- a/mods/testmod/dllmain.cpp
+++ b/mods/testmod/dllmain.cpp
@@ -35,10 +35,10 @@ sc2kfix_mod_hook_t stModHooks[] = {
 sc2kfix_mod_info_t stModInfo = {
 	/* .iModInfoVersion = */ 1,
 	/* .iModVersionMajor = */ 0,
-	/* .iModVersionMinor = */ 2,
+	/* .iModVersionMinor = */ 3,
 	/* .iModVersionPatch = */ 0,
 	/* .iMinimumVersionMajor = */ 0,
-	/* .iMinimumVersionMinor = */ 10,
+	/* .iMinimumVersionMinor = */ 11,
 	/* .iMinimumVersionPatch = */ 0,
 	/* .szModName = */ "Test Native Code Mod",
 	/* .szModShortName = */ "testmod",
@@ -56,19 +56,39 @@ HOOKCB sc2kfix_mod_info_t* HookCb_GetModInfo(void) {
 	return &stModInfo;
 }
 
+// Console commands can be added to the command tree just like in the plugin itself. Be sure to
+// remove any console commands you add as part of your cleanup process; a good place to do this is
+// in DllMain when dwReason is DLL_PROCESS_DETACH.
+bool ConsoleCommandTestmod(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	// No arguments allowed
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
+		bConsoleKeepCommandBuffer = true;
+		return true;
+	}
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	// Print a little hello message.
+	printf("You found me!\n");
+	return true;
+}
+
 // The DllMain function in each hook should be used sparingly and follow the best practices
 // conventions of the Windows API documentation for DLL entry points, as the DllMain function
 // is executed while under the global loader lock. See the following link for details:
 // https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-best-practices
-BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
-	switch (reason) {
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, LPVOID lpReserved) {
+	switch (dwReason) {
 	case DLL_PROCESS_ATTACH:
 		LOG(LOG_INFO, "testmod says hello!\n");
+		treeConsoleCommands["testmod"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandTestmod, "This command is brought to you by testmod!");
 		break;
 	case DLL_THREAD_ATTACH:
 	case DLL_THREAD_DETACH:
 		break;
 	case DLL_PROCESS_DETACH:
+		treeConsoleCommands["testmod"].~CommandTree();
 		LOG(LOG_INFO, "testmod says goodbye!\n");
 		break;
 	}

--- a/mods/testmod/dllmain.cpp
+++ b/mods/testmod/dllmain.cpp
@@ -1,5 +1,5 @@
 // sc2kfix/testmod dllmain.cpp: test/template mod with inline documentation
-// (c) 2025 sc2kfix project (https://sc2kfix.net) - released under the MIT license
+// (c) 2025-2026 sc2kfix project (https://sc2kfix.net) - released under the MIT license
 
 // These two lines are mandatory for sc2kfix mods. The first one ensures that all Windows API
 // calls use the ANSI calls instead of the Unicode calls, which aligns with the way that SimCity

--- a/modules/console_new.cpp
+++ b/modules/console_new.cpp
@@ -1,0 +1,638 @@
+// sc2kfix modules/console_new.cpp: sc2kfix console 2.0
+// (c) 2026 sc2kfix project (https://sc2kfix.net) - released under the MIT license
+
+// Notes: 2026-04-21 (@araxestroy)
+//
+// I'm very, very sorry.
+
+
+#undef UNICODE
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <mmsystem.h>
+#include <io.h>
+#include <signal.h>
+#include <conio.h>
+#include <fstream>
+#include <map>
+#include <regex>
+#include <string>
+
+#include <sc2kfix.h>
+#include <lua_glue.h>
+#include <commandtree.hpp>
+#include "../resource.h"
+
+#define CLI_DEBUG 0
+
+#if CLI_DEBUG == 0
+#define debug_printf drop_args
+#else
+#define debug_printf printf
+#endif
+
+#define printf_red(s, ...) printf(VT100_COLOUR_RED s VT100_DEFAULT, __VA_ARGS__)
+#define printf_lightred(s, ...) printf(VT100_COLOUR_BRIGHT_RED s VT100_DEFAULT, __VA_ARGS__)
+#define printf_yellow(s, ...) printf(VT100_COLOUR_YELLOW s VT100_DEFAULT, __VA_ARGS__)
+#define printf_lightblue(s, ...) printf(VT100_COLOUR_BRIGHT_BLUE s VT100_DEFAULT, __VA_ARGS__)
+
+void drop_args(...) {
+	return;
+}
+
+bool bConsoleInLuaREPL = false;
+bool bDontClearNextCommand = false;
+console::CommandTree treeConsoleCommands;
+
+void PrintAlignedStringMap(std::map<std::string, std::string> mapStr, int iPrefixSpaces = 3) {
+	std::map<std::string, std::string> mapOutput;
+	std::string strPrefixSpaces(iPrefixSpaces, ' ');
+	int iLeftAlign = 0;
+
+	for (auto s : mapStr) {
+		mapOutput[s.first] = s.second;
+		if (iLeftAlign < s.first.size())
+			iLeftAlign = s.first.size();
+	}
+
+	for (auto s : mapOutput)
+		printf("%s%s%s%s\n", strPrefixSpaces.c_str(), s.first.c_str(), std::string(3 + iLeftAlign - s.first.size(), ' ').c_str(), s.second.c_str());
+}
+
+bool ConsoleCommandRunLua(std::vector<std::string> args, int iBreakoutState) {
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap(
+			{
+				{"<[Enter]>", "Switches to the Lua REPL"},
+				{"<filename>", "Executes a file as a standalone Lua script"},
+			});
+		bDontClearNextCommand = true;
+		return true;
+	}
+
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+	
+	if (args.size() == 0) {
+		bConsoleInLuaREPL = true;
+		LuaRunREPL();
+		bConsoleInLuaREPL = false;
+	} else if (args.size() > 1)
+		return false;
+	else {
+		std::string strPossibleScriptName = args[0];
+		if (!FileExists(strPossibleScriptName.c_str())) {
+			strPossibleScriptName += ".lua";
+			if (!FileExists(strPossibleScriptName.c_str())) {
+				ConsoleLog(LOG_ERROR, "CORE: Couldn't find Lua script %s.\n", strPossibleScriptName.c_str());
+				return true;
+			}
+		}
+
+		// Spin up a new Lua VM, set up the glue logic, load the file, and run it.
+		lua_State* L = luaL_newstate();
+		luaL_openlibs(L);
+		luaL_dostring(L,
+			"mod_info = {}\n"
+			"mod_info.name = \"sc2kfix Lua REPL\"\n"
+			"mod_info.shortname = \"repl\"\n");
+		LuaGlueSetupState(L);
+		luaL_dofile(L, strPossibleScriptName.c_str());
+		lua_close(L);
+	}
+	
+	return true;
+}
+
+bool ConsoleCommandShowDebug(std::vector<std::string> args, int iBreakoutState) {
+	// No arguments allowed
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		bDontClearNextCommand = true;
+		return false;
+	}
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	printf("Debugging labels enabled: ");
+
+	if (guzzardo_debug)
+		printf("GUZZ=0x%08X ", guzzardo_debug);
+	if (mci_debug)
+		printf("MCI=0x%08X ", mci_debug);
+	if (military_debug)
+		printf("MIL=0x%08X ", military_debug);
+	if (mischook_debug)
+		printf("MISC=0x%08X ", mischook_debug);
+	if (modloader_debug)
+		printf("MODS=0x%08X ", modloader_debug);
+	if (mov_debug)
+		printf("MOV=0x%08X ", mov_debug);
+	if (mus_debug)
+		printf("MUS=0x%08X ", mus_debug);
+	if (registry_debug)
+		printf("REG=0x%08X ", registry_debug);
+	if (sc2x_debug)
+		printf("SC2X=0x%08X ", sc2x_debug);
+	if (snd_debug)
+		printf("SND=0x%08X ", snd_debug);
+	if (sprite_debug)
+		printf("SPR=0x%08X ", sprite_debug);
+	if (timer_debug)
+		printf("TIMER=0x%08X ", timer_debug);
+	if (updatenotifier_debug)
+		printf("UPD=0x%08X ", updatenotifier_debug);
+
+	printf("\n");
+	return true;
+}
+
+bool ConsoleCommandShowVersion(std::vector<std::string> args, int iBreakoutState) {
+	std::string strProgramName = "SimCity 2000";
+	std::string strProgramVersion = "unknown";
+
+	// No arguments allowed
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		bDontClearNextCommand = true;
+		return false;
+	}
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	if (dwSC2KFixMode == SC2KFIX_MODE_SC2K) {
+		switch (dwDetectedVersion) {
+		case VERSION_SC2K_1995:
+			strProgramVersion = "1995 CD Collection";
+			break;
+		case VERSION_SC2K_1996:
+			strProgramVersion = "1996 Special Edition";
+			break;
+		}
+	}
+	else if (dwSC2KFixMode == SC2KFIX_MODE_SC2KDEMO) {
+		if (dwDetectedVersion == VERSION_SC2K_DEMO)
+			strProgramVersion = "Interactive Demo";
+	}
+	else if (dwSC2KFixMode == SC2KFIX_MODE_SCURK) {
+		strProgramName = "SCURK";
+		switch (dwDetectedVersion) {
+		case VERSION_SCURK_PRIMARY:
+			strProgramVersion = "1995 (Primary version)";
+			break;
+		case VERSION_SCURK_1996:
+			strProgramVersion = "1996 Network Edition";
+			break;
+		}
+	}
+	else
+		strProgramName = "Unknown";
+
+	// AF - the separation comma positioning in this case is deliberate
+	// in order to be a bit more "friendly" concerning missing or varied
+	// end-arguments depending on the build.
+	//
+	// Reworked this significantly due to some legal advice (araxestroy)
+	printf(
+		VT100_COLOUR_BRIGHT_WHITE "sc2kfix version %s - (c) 2025-2026 sc2kfix Project (https://sc2kfix.net)\n" VT100_DEFAULT
+		"Build info: %s\n"
+		"%s version: %s\n"
+		"Lua version: %s\n"
+		"Plugin loaded at 0x%08X\n\n"
+
+		"This program includes code from the following projects:\n"
+		"  %s is (c) 1994-2025 Lua.org, PUC-Rio; made available under the MIT License\n"
+		"  FluidSynth is (c) FluidSynth; made available under the LGPL 2.1 license\n\n"
+
+		"Licenses for third-party code can be found in the sc2kfix repository and distribution under\n"
+		"the `thirdparty` directory. The sc2kfix plugin, example mods, and frameworks are released\n"
+		"under the terms of the MIT license unless otherwise stated.\n\n"
+
+		"SimCity 2000 is a registered trademark of Electronic Arts, Inc.\n",
+		szSC2KFixVersion,
+		szSC2KFixBuildInfo,
+		strProgramName.c_str(),
+		strProgramVersion.c_str(),
+		LUA_VERSION,
+		(DWORD)hSC2KFixModule,
+		LUA_VERSION
+	);
+
+	return true;
+}
+
+void NewConsoleInitializeCommands(console::CommandTree& treeCommands) {
+	treeCommands["run"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Run Lua REPL or scripts");
+	treeCommands["run"]["lua"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandRunLua, "Run Lua REPL or scripts");
+	treeCommands["show"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Display various game and plugin information");
+	treeCommands["show"]["debug"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowDebug, "Display enabled debugging options");
+	treeCommands["show"]["version"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowVersion, "Show sc2kfix and library version info");
+}
+
+DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
+	std::string strCommand;
+	int breakout = BREAKOUT_NONE;
+	bool bFullCommand = false;
+	bool bDoneQuestionOut = false;
+	bool bDoJuniperStyle = true;
+	bool bConsoleUndocumentedMode = false;
+	bDontClearNextCommand = false;
+
+	// Initialize the console
+	Sleep(200);
+	SetConsoleCtrlHandler(ConsoleCtrlHandler, TRUE);
+	NewConsoleInitializeCommands(treeConsoleCommands);
+
+	// HIC SUNT DRACONES
+	while (true) {
+		if (bConsoleUndocumentedMode)
+			printf(VT100_COLOUR_BRIGHT_WHITE "sc2kfix# " VT100_DEFAULT "%s", strCommand.c_str());
+		else
+			printf(VT100_COLOUR_BRIGHT_WHITE "sc2kfix> " VT100_DEFAULT "%s", strCommand.c_str());
+		breakout = BREAKOUT_NONE;
+		bDoneQuestionOut = false;
+		while (!breakout) {
+			int c = _getch();
+			switch (c) {
+			case CTRL('C'):
+				printf("\n");
+				breakout = BREAKOUT_INTERRUPT;
+				break;
+			case '\r':
+			case '\n':
+				printf("\n");
+				breakout = BREAKOUT_RETURN;
+				break;
+			case '?':
+				printf("?\n");
+				breakout = BREAKOUT_QUESTION;
+				break;
+			case '\t':
+				printf("\n");
+				breakout = BREAKOUT_TAB;
+				break;
+			case ' ':
+				if (strCommand == "") {
+					printf("\a");
+					continue;
+				}
+				else if (bDoJuniperStyle) {
+					breakout = BREAKOUT_SPACE;
+					break;
+				}
+				else {
+					putc(c, stdout);
+					strCommand.push_back(c);
+					continue;
+				}
+			case '\b':
+				if (strCommand == "") {
+					printf("\a");
+					continue;
+				}
+				strCommand.pop_back();
+				printf("\b \b");
+				continue;
+			default:
+				putc(c, stdout);
+				strCommand.push_back(c);
+				continue;
+			}
+		}
+
+		strCommand.erase(std::find_if(strCommand.rbegin(), strCommand.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), strCommand.end());
+
+		std::vector<std::string> vecSplit;
+		if (!string_split(strCommand, vecSplit)) {
+			printf_yellow("Unmatched quote.\n");
+			continue;
+		};
+
+		debug_printf("vecSplit.size: %d\n", vecSplit.size());
+
+		if ((bDoJuniperStyle && breakout == BREAKOUT_SPACE) || breakout == BREAKOUT_QUESTION || breakout == BREAKOUT_TAB) {
+			int iDepth = 0;
+			console::CommandTree* treePointer = &treeConsoleCommands;
+			while (iDepth < vecSplit.size()) {
+				if (treePointer->hasKey(vecSplit[iDepth])) {
+					//printf("%d: found key\n", iDepth);
+					if ((*treePointer)[vecSplit[iDepth]].ObjectType() == console::CommandTree::Class::Object) {
+						//printf("%d: found object\n", iDepth);
+						treePointer = &(*treePointer)[vecSplit[iDepth++]];
+
+						if (vecSplit.size() == iDepth && !treePointer->hasKey(""))
+							break;
+
+						if (vecSplit.size() == iDepth && !treePointer->hasKey(vecSplit[iDepth - 1])) {
+							debug_printf("bFC 1\n");
+							bFullCommand = true;
+						}
+
+						if (vecSplit.size() == iDepth && treePointer->hasKey("")) {
+							//printf("%d: found nested command\n", iDepth);
+							if ((*treePointer)[""].ToCommand().iType == COMMAND_TYPE_BRANCH && !treePointer->hasKey(vecSplit[iDepth - 1])) {
+								debug_printf("bFC 2 -- \"%s\"\n", vecSplit[iDepth - 1].c_str());
+								bFullCommand = true;
+								break;
+							}
+						}
+						else if (!treePointer->hasKey(vecSplit[iDepth]) && treePointer->hasKey("")) {
+							if ((*treePointer)[""].ToCommand().iType == COMMAND_TYPE_BRANCH && !treePointer->hasKey(vecSplit[iDepth])) {
+								debug_printf("bFC 3 -- \"%s\"\n", vecSplit[iDepth - 1].c_str());
+								bFullCommand = false;
+								break;
+							}
+						}
+						else if (treePointer->hasKey(vecSplit[iDepth])) {
+							debug_printf("bFC 4 -- \"%s\"\n", vecSplit[iDepth].c_str());
+							bFullCommand = true;
+							break;
+						}
+						else {
+							bFullCommand = false;
+							break;
+						}
+
+						//printf("%d: continue\n", iDepth);
+						continue;
+					}
+					else if ((*treePointer)[vecSplit[iDepth]].ObjectType() == console::CommandTree::Class::Command) {
+						//printf("%d: found command\n", iDepth);
+						debug_printf("bFC 5\n");
+						bFullCommand = true;
+						break;
+					}
+				}
+				else {
+					bFullCommand = false;
+					break;
+				}
+			}
+		}
+
+		//for (int i = 0; i < vecSplit.size(); i++)
+			//printf("%d: \"%s\"\n", i, vecSplit[i].c_str());
+
+		/*if (breakout == BREAKOUT_SPACE && bFullCommand) {
+			putc(' ', stdout);
+			strCommand.push_back(' ');
+		}*/
+
+		if (bFullCommand && (breakout == BREAKOUT_TAB || breakout == BREAKOUT_SPACE)) {
+			debug_printf("bFullCommand\n");
+			strCommand.push_back(' ');
+
+			if (breakout == BREAKOUT_SPACE)
+				printf("\r");
+				//printf("\x1B[1K\r");
+		}
+
+		if (breakout == BREAKOUT_QUESTION || breakout == BREAKOUT_TAB || (breakout == BREAKOUT_SPACE)) {
+			int iDepth = 0;
+			console::CommandTree* treePointer = &treeConsoleCommands;
+
+			std::map<std::string, std::string> mapOutput;
+			int iLongestCommand = 0;
+
+			if (vecSplit.size() == 0) {
+				for (auto s : treePointer->ObjectRange()) {
+					if ((*treePointer)[s.first].ObjectType() == console::CommandTree::Class::Command) {
+						mapOutput[s.first] = s.second.ToCommand().szDescription;
+						if (iLongestCommand < s.first.size())
+							iLongestCommand = s.first.size();
+					}
+					else if ((*treePointer)[s.first].ObjectType() == console::CommandTree::Class::Object && s.second.hasKey("")) {
+						mapOutput[s.first + " ..."] = s.second[""].ToCommand().szDescription;
+						if (iLongestCommand < s.first.size() + 4)
+							iLongestCommand = s.first.size() + 4;
+					}
+				}
+
+				if (breakout == BREAKOUT_SPACE)
+					printf("\n");
+
+				for (auto s : mapOutput)
+					printf("   %s%s%s\n", s.first.c_str(), std::string(3 + iLongestCommand - s.first.size(), ' ').c_str(), s.second.c_str());
+
+				bDoneQuestionOut = true;
+				continue;
+			}
+
+			bool bGo = false;
+
+			while (iDepth < vecSplit.size()) {
+				if (treePointer->hasKey(vecSplit[iDepth])) {
+					//printf("%d: found key\n", iDepth);
+					if ((*treePointer)[vecSplit[iDepth]].ObjectType() == console::CommandTree::Class::Object) {
+						//printf("%d: found object\n", iDepth);
+						treePointer = &(*treePointer)[vecSplit[iDepth++]];
+
+						if (vecSplit.size() == iDepth && treePointer->hasKey("")) {
+							//printf("%d: found nested command\n", iDepth);
+							bGo = true;
+							break;
+						}
+
+						//printf("%d: continue\n", iDepth);
+						continue;
+					}
+					else if ((*treePointer)[vecSplit[iDepth]].ObjectType() == console::CommandTree::Class::Command) {
+						if (breakout != BREAKOUT_QUESTION)
+							bGo = true;
+						break;
+					}
+				}
+				else {
+					bGo = true;
+					break;
+				}
+			}
+
+			if (iDepth == vecSplit.size()) {
+				if (strCommand[strCommand.size() - 1] != ' ')
+					strCommand.push_back(' ');
+				vecSplit.push_back("");
+			}
+
+			if (bGo) {
+				int i = 0;
+				for (auto s : treePointer->ObjectRange()) {
+					std::string s2 = s.first;
+					if ((*treePointer)[s.first].ObjectType() == console::CommandTree::Class::Command) {
+						if (!string_starts_with(s2, vecSplit[iDepth].c_str()))
+							continue;
+						if (s.first == "" && s.second.ToCommand().iType != COMMAND_TYPE_BRANCH) {
+							mapOutput["..."] = s.second.ToCommand().szDescription;
+							if (iLongestCommand < 3)
+								iLongestCommand = 3;
+
+						}
+						else {
+							mapOutput[s.first] = s.second.ToCommand().szDescription;
+							if (iLongestCommand < s.first.size())
+								iLongestCommand = s.first.size();
+						}
+					}
+					else if ((*treePointer)[s.first].ObjectType() == console::CommandTree::Class::Object && s.second.hasKey("")) {
+						if (!string_starts_with(s2, vecSplit[iDepth].c_str()))
+							continue;
+						mapOutput[s.first + " ..."] = s.second[""].ToCommand().szDescription;
+						if (iLongestCommand < s.first.size() + 4)
+							iLongestCommand = s.first.size() + 4;
+					}
+				}
+
+				//printf("%d: itsame\n", iDepth);
+
+				strCommand.erase(std::find_if(strCommand.rbegin(), strCommand.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), strCommand.end());
+
+				if (breakout == BREAKOUT_TAB || breakout == BREAKOUT_SPACE) {
+					int i = 0;
+					std::map<std::string, std::string> mapSort = mapOutput;
+
+					for (auto s : mapSort) {
+						std::string s2 = s.first;
+
+						if (string_ends_with(s2, " ...")) {
+							s2.pop_back();
+							s2.pop_back();
+							s2.pop_back();
+							s2.pop_back();
+						}
+
+						if (s2.size() > i)
+							i = s2.size();
+					}
+					for (auto s : mapSort) {
+						std::string s2 = s.first;
+
+						if (string_ends_with(s2, " ...")) {
+							s2.pop_back();
+							s2.pop_back();
+							s2.pop_back();
+							s2.pop_back();
+						}
+						if (s2.size() < i)
+							i = s2.size();
+					}
+
+					//printf("shortest command: %d\n", i);
+
+					bool local_breakout = false;
+					int j;
+					for (j = vecSplit[iDepth].size(); j < i; j++) {
+						char c = mapOutput.begin()->first[j];
+						for (auto s : mapOutput) {
+							if (s.first[j] != c) {
+								local_breakout = true;
+								break;
+							}
+						}
+						if (local_breakout)
+							break;
+						vecSplit[iDepth].push_back(c);
+						strCommand.push_back(c);
+					}
+					if (i == j) {
+						bFullCommand = true;
+						debug_printf("autocompleted whole command\n");
+					}
+				}
+
+				if (mapOutput.size() == 0) {
+					printf_yellow("%sInvalid argument.\n", breakout == BREAKOUT_SPACE ? "\n" : "");
+					bDoneQuestionOut = true;
+				}
+				else if (!(mapOutput.size() == 1 && breakout == BREAKOUT_SPACE)) {
+					bDoneQuestionOut = true;
+
+					if (mapOutput.size() != 1 && breakout == BREAKOUT_SPACE && !bFullCommand)
+						printf("\n");
+
+					for (auto s : mapOutput) {
+						if (s.first != "" && (breakout == BREAKOUT_TAB || breakout == BREAKOUT_QUESTION || (breakout == BREAKOUT_SPACE && !bFullCommand)))
+							printf("   %s%s%s\n", s.first.c_str(), std::string(3 + iLongestCommand - s.first.size(), ' ').c_str(), s.second.c_str());
+					}
+
+					if (bFullCommand)
+						strCommand.push_back(' ');
+				}
+
+				if (mapOutput.size() == 1) {
+					if (breakout == BREAKOUT_SPACE) {
+						if (bFullCommand) {
+							strCommand.push_back(' ');
+							printf("\r");
+							//printf("\x1B[1K\r");
+						}
+					}
+				}
+			}
+		}
+
+		if (breakout == BREAKOUT_RETURN || breakout == BREAKOUT_INTERRUPT || (breakout == BREAKOUT_QUESTION && !bDoneQuestionOut)) {
+			if (breakout == BREAKOUT_INTERRUPT)
+				continue;
+
+			strCommand.erase(std::find_if(strCommand.rbegin(), strCommand.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), strCommand.end());
+
+			int iDepth = 0;
+			console::CommandTree* treePointer = &treeConsoleCommands;
+			while (iDepth < vecSplit.size()) {
+				if (treePointer->hasKey(vecSplit[iDepth])) {
+					debug_printf("%d: found key\n", iDepth);
+					if ((*treePointer)[vecSplit[iDepth]].ObjectType() == console::CommandTree::Class::Object) {
+						debug_printf("%d: found object\n", iDepth);
+						treePointer = &(*treePointer)[vecSplit[iDepth++]];
+						if (breakout == BREAKOUT_QUESTION)
+							continue;
+
+						if (vecSplit.size() == iDepth && !treePointer->hasKey("")) {
+							printf_yellow("Invalid argument.\n");
+							break;
+						}
+
+						if ((vecSplit.size() == iDepth && treePointer->hasKey("") ||
+							!treePointer->hasKey(vecSplit[iDepth]) && treePointer->hasKey("")) &&
+							breakout != BREAKOUT_QUESTION) {
+							debug_printf("%d: found nested command\n", iDepth);
+							if ((*treePointer)[""].ToCommand().iType == COMMAND_TYPE_BRANCH) {
+								printf_yellow("Invalid argument.\n");
+								break;
+							}
+
+							std::vector<std::string> vecArgs;
+							for (int i = iDepth + 1; i < vecSplit.size(); i++)
+								vecArgs.push_back(vecSplit[i]);
+
+							if (!(*treePointer)[""].ToCommand().pCommand(vecArgs, breakout))
+								printf_yellow("Invalid argument.\n");
+							break;
+						}
+
+						debug_printf("%d: continue\n", iDepth);
+						continue;
+					}
+					else if ((*treePointer)[vecSplit[iDepth]].ObjectType() == console::CommandTree::Class::Command) {
+						debug_printf("%d: found command\n", iDepth);
+						std::vector<std::string> vecArgs;
+						for (int i = iDepth + 1; i < vecSplit.size(); i++)
+							vecArgs.push_back(vecSplit[i]);
+
+						if (!((*treePointer)[vecSplit[iDepth]].ToCommand().pCommand(vecArgs, breakout)))
+							printf_yellow("Invalid argument.\n");
+						break;
+					}
+				}
+				else {
+					printf_yellow("Invalid argument.\n");
+					break;
+				}
+			}
+
+			if (!bDontClearNextCommand && !bDoneQuestionOut)
+				strCommand = "";
+
+			bDontClearNextCommand = false;
+		}
+	}
+}

--- a/modules/console_new.cpp
+++ b/modules/console_new.cpp
@@ -154,6 +154,108 @@ bool ConsoleCommandClear(std::vector<std::string> args, int iBreakoutState, intp
 	return true;
 }
 
+bool ConsoleCommandFixupThingsClear(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	int iIndex = 0;
+
+	if (dwDetectedVersion != VERSION_SC2K_1996) {
+		printf_yellow("Command only available when attached to 1996 Special Edition.\n");
+		return true;
+	}
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap(
+			{
+				{"all", "Remove every Thing entity on the map (potentially dangerous!)"},
+				{"index <index>", "XTHG index of Thing to remove"},
+				{"type <type>", "Remove all Things of a specific type"},
+			});
+		bConsoleKeepCommandBuffer = true;
+		return true;
+	}
+
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	// Arguments are required for this command
+	if (args.size() == 0) {
+		bConsoleKeepCommandBuffer = true;
+		return false;
+	}
+
+	// Parse arguments
+	for (size_t i = 0; i < args.size(); i++) {
+		// all
+		if (args[i] == "all") {
+			// Danger, Will Robinson!
+			DeleteMapThingByIdx_SC2K1996(-1);
+			ConsoleLog(LOG_INFO, "Cleared all things by console command.\n");
+			continue;
+		}
+
+		// index <index>
+		if (args[i] == "index") {
+			if (++i >= args.size())
+				return false;
+
+			if (!sscanf_s(args[i].c_str(), "%u", &iIndex))
+				return false;
+
+			if (iIndex >= MIN_THING_IDX && iIndex <= MAX_THING_IDX) {
+				DeleteMapThingByIdx_SC2K1996(iIndex);
+				ConsoleLog(LOG_INFO, "Cleared thing index %d by console command.\n", iIndex);
+			} else
+				return false;
+
+			continue;
+		}
+		// type <type>
+		if (args[i] == "type") {
+			if (++i >= args.size())
+				return false;
+
+			if (args[i] == "plane") {
+				DeleteAllPlanes_SC2K1996();
+				continue;
+			} else if (args[i] == "helicopter") {
+				DeleteAllCopters_SC2K1996();
+				continue;
+			} else if (args[i] == "cargoship") {
+				DeleteAllShips_SC2K1996();
+				continue;
+			} else if (args[i] == "sailboat") {
+				DeleteAllSailboats_SC2K1996();
+				continue;
+			} else if (args[i] == "train") {
+				DeleteAllTrains_SC2K1996();
+				continue;
+			} else if (args[i] == "maxisman") {
+				DeleteAllMaxisMen_SC2K1996();
+				continue;
+			} else if (args[i] == "monster") {
+				DeleteAllMonsters_SC2K1996();
+				continue;
+			} else if (args[i] == "tornado") {
+				DeleteAllTornadoes_SC2K1996();
+				continue;
+			} else if (args[i] == "policedeploy") {
+				DeleteAllPoliceDeploys_SC2K1996();
+				continue;
+			} else if (args[i] == "firedeploy") {
+				DeleteAllFireDeploys_SC2K1996();
+				continue;
+			} else if (args[i] == "militarydeploy") {
+				DeleteAllMilitaryDeploys_SC2K1996();
+				continue;
+			} else
+				return false;
+		}
+
+		// Invalid arugment, bail out
+		return false;
+	}
+
+	return true;
+}
+
 #define SETDEBUGOP(keyword, var, description) \
 	if (args[i] == keyword || bSetAll) { \
 		var ## _debug = dwOperation; \
@@ -952,6 +1054,9 @@ bool ConsoleCommandShowVersion(std::vector<std::string> args, int iBreakoutState
 
 void NewConsoleInitializeCommands(console::CommandTree& treeCommands) {
 	treeCommands["clear"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandClear, "Clear the console");
+	treeCommands["fixup"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Fix up engine gremlins");
+	treeCommands["fixup"]["things"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Fixup commands for Thing entities");
+	treeCommands["fixup"]["things"]["clear"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandFixupThingsClear, "Clear (specific) Thing entities");
 	treeCommands["run"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Run Lua REPL or scripts");
 	treeCommands["run"]["lua"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandRunLua, "Run Lua REPL or scripts");
 	treeCommands["run"]["test"] = ConsoleCommand(COMMAND_TYPE_UNDOCUMENTED, ConsoleCommandRunTest, "Test command");

--- a/modules/console_new.cpp
+++ b/modules/console_new.cpp
@@ -45,66 +45,6 @@ bool bConsoleInLuaREPL = false;
 bool bDontClearNextCommand = false;
 console::CommandTree treeConsoleCommands;
 
-void PrintAlignedStringMap(std::map<std::string, std::string> mapStr, int iPrefixSpaces = 3) {
-	std::map<std::string, std::string> mapOutput;
-	std::string strPrefixSpaces(iPrefixSpaces, ' ');
-	size_t iLeftAlign = 0;
-
-	for (auto s : mapStr) {
-		mapOutput[s.first] = s.second;
-		if (iLeftAlign < s.first.size())
-			iLeftAlign = s.first.size();
-	}
-
-	for (auto s : mapOutput)
-		printf("%s%s%s%s\n", strPrefixSpaces.c_str(), s.first.c_str(), std::string(3 + iLeftAlign - s.first.size(), ' ').c_str(), s.second.c_str());
-}
-
-bool ConsoleCommandRunLua(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
-	if (iBreakoutState == BREAKOUT_QUESTION) {
-		PrintAlignedStringMap(
-			{
-				{"<[Enter]>", "Switches to the Lua REPL"},
-				{"<filename>", "Executes a file as a standalone Lua script"},
-			});
-		bDontClearNextCommand = true;
-		return true;
-	}
-
-	if (iBreakoutState != BREAKOUT_RETURN)
-		return false;
-	
-	if (args.size() == 0) {
-		bConsoleInLuaREPL = true;
-		LuaRunREPL();
-		bConsoleInLuaREPL = false;
-	} else if (args.size() > 1)
-		return false;
-	else {
-		std::string strPossibleScriptName = args[0];
-		if (!FileExists(strPossibleScriptName.c_str())) {
-			strPossibleScriptName += ".lua";
-			if (!FileExists(strPossibleScriptName.c_str())) {
-				ConsoleLog(LOG_ERROR, "CORE: Couldn't find Lua script %s.\n", strPossibleScriptName.c_str());
-				return true;
-			}
-		}
-
-		// Spin up a new Lua VM, set up the glue logic, load the file, and run it.
-		lua_State* L = luaL_newstate();
-		luaL_openlibs(L);
-		luaL_dostring(L,
-			"mod_info = {}\n"
-			"mod_info.name = \"sc2kfix Lua REPL\"\n"
-			"mod_info.shortname = \"repl\"\n");
-		LuaGlueSetupState(L);
-		luaL_dofile(L, strPossibleScriptName.c_str());
-		lua_close(L);
-	}
-	
-	return true;
-}
-
 static BYTE AttemptSafeReadByte(BYTE* address) {
 	__try {
 		return *address;
@@ -161,10 +101,87 @@ static void AttemptSafeMemcpy(BYTE* dest, BYTE* src, size_t bytes) {
 	}
 }
 
+void PrintAlignedStringMap(std::map<std::string, std::string> mapStr, int iPrefixSpaces = 3) {
+	std::map<std::string, std::string> mapOutput;
+	std::string strPrefixSpaces(iPrefixSpaces, ' ');
+	size_t iLeftAlign = 0;
+
+	for (auto s : mapStr) {
+		mapOutput[s.first] = s.second;
+		if (iLeftAlign < s.first.size())
+			iLeftAlign = s.first.size();
+	}
+
+	for (auto s : mapOutput)
+		printf("%s%s%s%s\n", strPrefixSpaces.c_str(), s.first.c_str(), std::string(3 + iLeftAlign - s.first.size(), ' ').c_str(), s.second.c_str());
+}
+
+bool ConsoleCommandClear(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	// No arguments allowed
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
+		bDontClearNextCommand = true;
+		return true;
+	}
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	// It is the year 2026. Don't let anyone tell you Windows doesn't support VT100 control codes.
+	printf("\x1b[2J\x1b[0;0H");
+
+	return true;
+}
+
+bool ConsoleCommandRunLua(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap(
+			{
+				{"<[Enter]>", "Switches to the Lua REPL"},
+				{"<filename>", "Executes a file as a standalone Lua script"},
+			});
+		bDontClearNextCommand = true;
+		return true;
+	}
+
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+	
+	if (args.size() == 0) {
+		bConsoleInLuaREPL = true;
+		LuaRunREPL();
+		bConsoleInLuaREPL = false;
+	} else if (args.size() > 1)
+		return false;
+	else {
+		std::string strPossibleScriptName = args[0];
+		if (!FileExists(strPossibleScriptName.c_str())) {
+			strPossibleScriptName += ".lua";
+			if (!FileExists(strPossibleScriptName.c_str())) {
+				ConsoleLog(LOG_ERROR, "CORE: Couldn't find Lua script %s.\n", strPossibleScriptName.c_str());
+				return true;
+			}
+		}
+
+		// Spin up a new Lua VM, set up the glue logic, load the file, and run it.
+		lua_State* L = luaL_newstate();
+		luaL_openlibs(L);
+		luaL_dostring(L,
+			"mod_info = {}\n"
+			"mod_info.name = \"sc2kfix Lua REPL\"\n"
+			"mod_info.shortname = \"repl\"\n");
+		LuaGlueSetupState(L);
+		luaL_dofile(L, strPossibleScriptName.c_str());
+		lua_close(L);
+	}
+	
+	return true;
+}
+
 bool ConsoleCommandShowMemory(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
 	DWORD dwAddress = NULL;
 	int iElementsCount = 1;
 	bool bAddressScanned = false;
+	int iBase = 16;
 
 	BYTE b;
 	WORD w;
@@ -185,6 +202,8 @@ bool ConsoleCommandShowMemory(std::vector<std::string> args, int iBreakoutState,
 			{
 				{"<address>", "Address to examine in hexadecimal"},
 				{"[count <count>]", "Number of elements to show (default 1)"},
+				{"[decimal]", "Display integers in decimal instead of hex"},
+				{"[octal]", "Display integers in octal instead of hex"},
 			});
 		bDontClearNextCommand = true;
 		return true;
@@ -193,8 +212,11 @@ bool ConsoleCommandShowMemory(std::vector<std::string> args, int iBreakoutState,
 	if (iBreakoutState != BREAKOUT_RETURN)
 		return false;
 
-	if (args.size() == 0)
+	// Arguments are required for this command
+	if (args.size() == 0) {
+		bDontClearNextCommand = true;
 		return false;
+	}
 
 	// Parse arguments
 	for (size_t i = 0; i < args.size(); i++) {
@@ -206,6 +228,18 @@ bool ConsoleCommandShowMemory(std::vector<std::string> args, int iBreakoutState,
 			if (!sscanf_s(args[i].c_str(), "%u", &iElementsCount))
 				return false;
 
+			continue;
+		}
+
+		// [decimal]
+		if (args[i] == "decimal" && iBase == 16) {
+			iBase = 10;
+			continue;
+		}
+
+		// [octal]
+		if (args[i] == "octal" && iBase == 16) {
+			iBase = 8;
 			continue;
 		}
 
@@ -224,33 +258,57 @@ bool ConsoleCommandShowMemory(std::vector<std::string> args, int iBreakoutState,
 		return false;
 
 	try {
+		// Display single items in both hexadecimal and decimal by default
 		if (iElementsCount == 1) {
 			printf("0x%08X: ", dwAddress);
 			switch (iOptParam) {
 			case 1:
 				b = AttemptSafeReadByte((BYTE*)dwAddress);
-				printf("(byte) 0x%02X / %d\n", b, b);
+				if (iBase == 10)
+					printf("(byte) %u / %d\n", b, b);
+				else if (iBase == 8)
+					printf("(byte) %03o\n", b);
+				else
+					printf("(byte) 0x%02X / %d\n", b, b);
 				break;
 			case 2:
 				w = AttemptSafeReadWord((WORD*)dwAddress);
-				printf("(word) 0x%04X / %d\n", w, w);
+				if (iBase == 10)
+					printf("(word) %u / %d\n", w, w);
+				else if (iBase == 8)
+					printf("(word) %06o\n", w);
+				else
+					printf("(word) 0x%04X / %d\n", w, w);
 				break;
 			case 4:
 				dw = AttemptSafeReadDword((DWORD*)dwAddress);
 				if (bFloat)
 					printf("(float) %f\n", *(float*)&dw);
-				else
-					printf("(dword) 0x%08X / %d\n", dw, dw);
+				else {
+					if (iBase == 10)
+						printf("(dword) %u / %d\n", dw, dw);
+					else if (iBase == 8)
+						printf("(dword) %011o\n", dw);
+					else
+						printf("(dword) 0x%08X / %d\n", dw, dw);
+				}
 				break;
 			case 8:
 				qw = AttemptSafeReadQword((uint64_t*)dwAddress);
 				if (bFloat)
 					printf("(double) %lf\n", *(double*)&qw);
-				else
-					printf("(qword) 0x%016llX / %lld\n", qw, qw);
+				else {
+					if (iBase == 10)
+						printf("(qword) %llu / %lld\n", qw, qw);
+					else if (iBase == 8)
+						printf("(qword) %022llo\n", qw);
+					else
+						printf("(qword) 0x%016llX / %lld\n", qw, qw);
+				}
 				break;
 			}
 		} else {
+			// Display multiple elements (in hexadecimal for integers by default)
 			while (iElementsCount > 0) {
 				printf("0x%08X:", dwAddress);
 				size_t uNextElements = (iElementsCount * iOptParam > 16 ? 16 / iOptParam : iElementsCount);
@@ -261,22 +319,44 @@ bool ConsoleCommandShowMemory(std::vector<std::string> args, int iBreakoutState,
 				for (int i = 0; i < uNextElements; i++) {
 					switch (iOptParam) {
 					case 1:
-						printf(" %02X", buf[i]);
+						if (iBase == 10)
+							printf(" %3u", buf[i]);
+						else if (iBase == 8)
+							printf(" %03o", buf[i]);
+						else
+							printf(" %02X", buf[i]);
 						break;
 					case 2:
-						printf(" %04X", *(WORD*)&buf[i * iOptParam]);
+						if (iBase == 10)
+							printf(" %5u", *(WORD*)&buf[i * iOptParam]);
+						else if (iBase == 8)
+							printf(" %06o", *(WORD*)&buf[i * iOptParam]);
+						else
+							printf(" %04X", *(WORD*)&buf[i * iOptParam]);
 						break;
 					case 4:
 						if (bFloat)
 							printf(" %f", *(float*)&buf[i * iOptParam]);
-						else
-							printf(" %08X", *(DWORD*)&buf[i * iOptParam]);
+						else {
+							if (iBase == 10)
+								printf(" %10u", *(DWORD*)&buf[i * iOptParam]);
+							else if (iBase == 8)
+								printf(" %011o", *(DWORD*)&buf[i * iOptParam]);
+							else
+								printf(" %08X", *(DWORD*)&buf[i * iOptParam]);
+						}
 						break;
 					case 8:
 						if (bFloat)
 							printf(" %lf", *(double*)&buf[i * iOptParam]);
-						else
-							printf(" %016llX", *(uint64_t*)&buf[i * iOptParam]);
+						else {
+							if (iBase == 10)
+								printf(" %20llu", *(uint64_t*)&buf[i * iOptParam]);
+							else if (iBase == 8)
+								printf(" %022llo", *(uint64_t*)&buf[i * iOptParam]);
+							else
+								printf(" %016llX", *(uint64_t*)&buf[i * iOptParam]);
+						}
 						break;
 					}
 				}
@@ -316,11 +396,96 @@ bool ConsoleCommandShowMemoryDouble(std::vector<std::string> args, int iBreakout
 	return ConsoleCommandShowMemory(args, iBreakoutState, 9);
 }
 
+bool ConsoleCommandShowMods(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	bool bDetailed = false;
+	bool bShowLuaMods = true;
+	bool bShowNativeMods = true;
+
+	if (dwDetectedVersion != VERSION_SC2K_1996) {
+		printf_yellow("Command only available when attached to 1996 Special Edition.\n");
+		return true;
+	}
+
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap(
+			{
+				{"<[Enter]>", "Executes this command"},
+				{"[detail]", "Shows verbose information about loaded mods"},
+				{"[lua]", "Only shows information about Lua mods"},
+				{"[native]", "Only shows information about native code mods"},
+			});
+		bDontClearNextCommand = true;
+		return true;
+	}
+
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	// Parse arguments
+	for (size_t i = 0; i < args.size(); i++) {
+		// [detail]
+		if (args[i] == "detail") {
+			bDetailed = true;
+			continue;
+		}
+
+		// [lua]
+		if (args[i] == "lua") {
+			bShowLuaMods = true;
+			bShowNativeMods = false;
+			continue;
+		}
+
+		// [native]
+		if (args[i] == "native") {
+			bShowLuaMods = false;
+			bShowNativeMods = true;
+			continue;
+		}
+
+		// Invalid argument, bail out
+		return false;
+	}
+
+	CONSOLE_SCREEN_BUFFER_INFO csbi;
+	GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
+
+	if (bShowNativeMods) {
+		printf("%d native code mods loaded:\n", mapLoadedNativeMods.size());
+		for (auto stNativeMod : mapLoadedNativeMods) {
+
+			const char* szModVersion = _strdup(FormatVersion(stNativeMod.second.iModVersionMajor, stNativeMod.second.iModVersionMinor, stNativeMod.second.iModVersionPatch));
+			const char* szModMinimumVersion = _strdup(FormatVersion(stNativeMod.second.iMinimumVersionMajor, stNativeMod.second.iMinimumVersionMinor, stNativeMod.second.iMinimumVersionPatch));
+
+			printf(
+				"   %s version %s (0x%08X)\n"
+				"      Mod Name:             %s\n"
+				"      Author:               %s\n"
+				"      Req. sc2kfix version: %s\n"
+				"      Description:          %s\n",
+				stNativeMod.second.szModShortName, szModVersion, (INT_PTR)stNativeMod.first,
+				stNativeMod.second.szModName,
+				stNativeMod.second.szModAuthor,
+				szModMinimumVersion,
+				WordWrap(stNativeMod.second.szModDescription, csbi.dwSize.X, 28).c_str());
+			if (bDetailed) {
+				printf("      Hooks:\n");
+				for (auto stHook : mapLoadedNativeModHooks[stNativeMod.first])
+					printf("         %s (pri %d)\n", stHook.szHookName, stHook.iHookPriority);
+			}
+			printf("\n");
+		}
+	}
+
+	return true;
+}
+
 bool ConsoleCommandShowDebug(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
 	// No arguments allowed
 	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap({{"<[Enter]>", "Execute this command"}});
 		bDontClearNextCommand = true;
-		return false;
+		return true;
 	}
 	if (iBreakoutState != BREAKOUT_RETURN)
 		return false;
@@ -364,8 +529,9 @@ bool ConsoleCommandShowVersion(std::vector<std::string> args, int iBreakoutState
 
 	// No arguments allowed
 	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
 		bDontClearNextCommand = true;
-		return false;
+		return true;
 	}
 	if (iBreakoutState != BREAKOUT_RETURN)
 		return false;
@@ -431,6 +597,7 @@ bool ConsoleCommandShowVersion(std::vector<std::string> args, int iBreakoutState
 }
 
 void NewConsoleInitializeCommands(console::CommandTree& treeCommands) {
+	treeCommands["clear"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandClear, "Clear the console");
 	treeCommands["run"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Run Lua REPL or scripts");
 	treeCommands["run"]["lua"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandRunLua, "Run Lua REPL or scripts");
 	treeCommands["show"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Display various game and plugin information");
@@ -442,6 +609,7 @@ void NewConsoleInitializeCommands(console::CommandTree& treeCommands) {
 	treeCommands["show"]["memory"]["qword"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMemoryQword, "Display quad word-sized elements");
 	treeCommands["show"]["memory"]["float"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMemoryFloat, "Display single precision floating point elements");
 	treeCommands["show"]["memory"]["double"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMemoryDouble, "Display double precision floating point elements");
+	treeCommands["show"]["mods"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMods, "Show loaded mods");
 	treeCommands["show"]["version"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowVersion, "Show sc2kfix and library version info");
 }
 
@@ -821,7 +989,7 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 							for (size_t i = iDepth + 1; i < vecSplit.size(); i++)
 								vecArgs.push_back(vecSplit[i]);
 
-							if (!(*treePointer)[""].ToCommand().pCommand(vecArgs, breakout, 0))
+							if (!(*treePointer)[""].ToCommand().pCommand(vecArgs, breakout, (*treePointer)[""].ToCommand().iOptParam))
 								printf_yellow("Invalid argument.\n");
 							break;
 						}
@@ -835,7 +1003,7 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 						for (size_t i = iDepth + 1; i < vecSplit.size(); i++)
 							vecArgs.push_back(vecSplit[i]);
 
-						if (!((*treePointer)[vecSplit[iDepth]].ToCommand().pCommand(vecArgs, breakout, 0)))
+						if (!((*treePointer)[vecSplit[iDepth]].ToCommand().pCommand(vecArgs, breakout, (*treePointer)[vecSplit[iDepth]].ToCommand().iOptParam)))
 							printf_yellow("Invalid argument.\n");
 						break;
 					}

--- a/modules/console_new.cpp
+++ b/modules/console_new.cpp
@@ -32,10 +32,17 @@
 #define debug_printf printf
 #endif
 
+#ifdef CONSOLE_ENABLED
+BOOL bConsoleEnabled = TRUE;
+#else 
+BOOL bConsoleEnabled = FALSE;
+#endif
+
 void drop_args(...) {
 	return;
 }
 
+HANDLE hConsoleThread;
 HOOKEXT bool bConsoleInLuaREPL = false;
 HOOKEXT bool bConsoleElevatedMode = false;
 HOOKEXT bool bConsoleKeepCommandBuffer = false;
@@ -1505,4 +1512,12 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 			bConsoleKeepCommandBuffer = false;
 		}
 	}
+}
+
+BOOL WINAPI ConsoleCtrlHandler(DWORD fdwCtrlType) {
+	switch (fdwCtrlType) {
+	case CTRL_C_EVENT:
+		return TRUE;
+	}
+	return FALSE;
 }

--- a/modules/console_new.cpp
+++ b/modules/console_new.cpp
@@ -396,6 +396,139 @@ bool ConsoleCommandShowMemoryDouble(std::vector<std::string> args, int iBreakout
 	return ConsoleCommandShowMemory(args, iBreakoutState, 9);
 }
 
+bool ConsoleCommandShowMicrosim(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	DWORD dwAddress = NULL;
+	int iMicrosimID = 0;
+	bool bListAllMicrosims = false;
+
+	if (dwDetectedVersion != VERSION_SC2K_1996) {
+		printf_yellow("Command only available when attached to 1996 Special Edition.\n");
+		return true;
+	}
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap(
+			{
+				{"all", "Display list of provisioned microsims"},
+				{"bigpark", "Display microsim data for large parks"},
+				{"bus", "Display microsim data for bus depots"},
+				{"hydro", "Display microsim data for hydroelectric dams"},
+				{"id <id>", "ID of specific microsim to examine"},
+				{"library", "Display microsim data for libraries"},
+				{"marina", "Display microsim data for marinas"},
+				{"museum", "Display microsim data for museums"},
+				{"rail", "Display microsim data for rail stations"},
+				{"subway", "Display microsim data for subway stations"},
+				{"wind", "Display microsim data for wind power plants"},
+			});
+		bDontClearNextCommand = true;
+		return true;
+	}
+
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	// Arguments are required for this command
+	if (args.size() == 0) {
+		bDontClearNextCommand = true;
+		return false;
+	}
+
+	// Parse arguments
+	for (size_t i = 0; i < args.size(); i++) {
+		// [id <id>]
+		if (args[i] == "id") {
+			if (++i >= args.size())
+				return false;
+
+			if (!sscanf_s(args[i].c_str(), "%u", &iMicrosimID))
+				return false;
+
+			continue;
+		}
+
+		// all
+		if (args[i] == "all") {
+			bListAllMicrosims = true;
+			continue;
+		}
+
+		// bigpark
+		if (args[i] == "bigpark") {
+			iMicrosimID = 6;
+			continue;
+		}
+
+		// bus
+		if (args[i] == "bus") {
+			iMicrosimID = 1;
+			continue;
+		}
+
+		// hydro
+		if (args[i] == "hydro") {
+			iMicrosimID = 5;
+			continue;
+		}
+
+		// library
+		if (args[i] == "library") {
+			iMicrosimID = 8;
+			continue;
+		}
+
+		// marina
+		if (args[i] == "marina") {
+			iMicrosimID = 9;
+			continue;
+		}
+
+		// museum
+		if (args[i] == "museum") {
+			iMicrosimID = 7;
+			continue;
+		}
+
+		// rail
+		if (args[i] == "rail") {
+			iMicrosimID = 2;
+			continue;
+		}
+
+		// subway
+		if (args[i] == "subway") {
+			iMicrosimID = 3;
+			continue;
+		}
+
+		// Invalid arugment, bail out
+		return false;
+	}
+
+	// Show list if requested
+	if (bListAllMicrosims) {
+		printf("Provisioned microsims:\n");
+		for (int i = 0; i <= MICROSIMID_MAX; i++)
+			if (GetMicroSimulatorTileID(i) != TILE_CLEAR)
+				printf("   %i: bTileID = %u\n", i, GetMicroSimulatorTileID(i));
+	} else {
+		if (iMicrosimID >= MICROSIMID_MIN && iMicrosimID <= MICROSIMID_MAX) {
+			BYTE iTileID = GetMicroSimulatorTileID(iMicrosimID);
+			printf(
+				"Microsim %i:\n"
+				"   Tile/Building:       %s (%u / 0x%02X)\n"
+				"   Data Stat0 (Byte):   %u\n"
+				"   Data Stat1 (Word 1): %u\n"
+				"   Data Stat2 (Word 2): %u\n"
+				"   Data Stat3 (Word 3): %u\n", iMicrosimID, szTileNames[iTileID], iTileID, iTileID, GetMicroSimulatorStat0(iMicrosimID),
+				GetMicroSimulatorStat1(iMicrosimID), GetMicroSimulatorStat2(iMicrosimID), GetMicroSimulatorStat3(iMicrosimID));
+			return true;
+		}
+		return false;
+	}
+
+	return true;
+}
+
 bool ConsoleCommandShowMods(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
 	bool bDetailed = false;
 	bool bShowLuaMods = true;
@@ -609,6 +742,7 @@ void NewConsoleInitializeCommands(console::CommandTree& treeCommands) {
 	treeCommands["show"]["memory"]["qword"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMemoryQword, "Display quad word-sized elements");
 	treeCommands["show"]["memory"]["float"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMemoryFloat, "Display single precision floating point elements");
 	treeCommands["show"]["memory"]["double"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMemoryDouble, "Display double precision floating point elements");
+	treeCommands["show"]["microsim"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMicrosim, "Show microsim data");
 	treeCommands["show"]["mods"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMods, "Show loaded mods");
 	treeCommands["show"]["version"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowVersion, "Show sc2kfix and library version info");
 }

--- a/modules/console_new.cpp
+++ b/modules/console_new.cpp
@@ -42,6 +42,7 @@ void drop_args(...) {
 }
 
 bool bConsoleInLuaREPL = false;
+bool bConsoleUndocumentedMode = false;
 bool bDontClearNextCommand = false;
 console::CommandTree treeConsoleCommands;
 
@@ -150,6 +151,24 @@ bool ConsoleCommandClear(std::vector<std::string> args, int iBreakoutState, intp
 	// It is the year 2026. Don't let anyone tell you Windows doesn't support VT100 control codes.
 	printf("\x1b[2J\x1b[0;0H");
 
+	return true;
+}
+
+bool ConsoleCommandSetUndocumented(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	// No arguments allowed
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
+		bDontClearNextCommand = true;
+		return true;
+	}
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	std::string& strRootName = *((std::string*)iOptParam);
+	if (strRootName == "set")
+		bConsoleUndocumentedMode = true;
+	else
+		bConsoleUndocumentedMode = false;
 	return true;
 }
 
@@ -858,6 +877,8 @@ void NewConsoleInitializeCommands(console::CommandTree& treeCommands) {
 	treeCommands["run"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Run Lua REPL or scripts");
 	treeCommands["run"]["lua"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandRunLua, "Run Lua REPL or scripts");
 	treeCommands["run"]["test"] = ConsoleCommand(COMMAND_TYPE_UNDOCUMENTED, ConsoleCommandRunTest, "Test command");
+	treeCommands["set"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Modify game and plugin behaviour");
+	treeCommands["set"]["undocumented"] = ConsoleCommand(COMMAND_TYPE_UNDOCUMENTED, ConsoleCommandSetUndocumented, "Enable/disable display of special commands", COMMAND_OPTPARAM_ROOTNAME);
 	treeCommands["show"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Display various game and plugin information");
 	treeCommands["show"]["audio"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Show audio engine info");
 	treeCommands["show"]["audio"]["buffers"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowAudioBuffers, "Dump loaded WAV buffer metadata");
@@ -880,6 +901,7 @@ void NewConsoleInitializeCommands(console::CommandTree& treeCommands) {
 
 	// Aliases
 	treeCommands["show"]["sound"] = treeCommands["show"]["audio"];
+	treeCommands["unset"] = treeCommands["set"];
 }
 
 DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
@@ -888,7 +910,6 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 	bool bFullCommand = false;
 	bool bDoneQuestionOut = false;
 	bool bDoJuniperStyle = true;
-	bool bConsoleUndocumentedMode = false;
 	bDontClearNextCommand = false;
 
 	// Initialize the console
@@ -1114,6 +1135,10 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 					if ((*treePointer)[s.first].ObjectType() == console::CommandTree::Class::Command) {
 						if (!string_starts_with(s2, vecSplit[iDepth].c_str()))
 							continue;
+						if (!bConsoleUndocumentedMode && s.second.ToCommand().iType == COMMAND_TYPE_UNDOCUMENTED ||
+							s.second.ToCommand().iType == COMMAND_TYPE_HIDDEN)
+							continue;
+
 						if (s.first == "" && s.second.ToCommand().iType != COMMAND_TYPE_BRANCH) {
 							mapOutput["..."] = s.second.ToCommand().szDescription;
 							if (iLongestCommand < 3)
@@ -1258,7 +1283,13 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 							for (size_t i = iDepth + 1; i < vecSplit.size(); i++)
 								vecArgs.push_back(vecSplit[i]);
 
-							if (!(*treePointer)[""].ToCommand().pCommand(vecArgs, breakout, (*treePointer)[""].ToCommand().iOptParam))
+							intptr_t iOptParam = NULL;
+							if ((*treePointer)[""].ToCommand().iOptParam == COMMAND_OPTPARAM_ROOTNAME)
+								iOptParam = (intptr_t)&vecSplit[0];
+							else if ((*treePointer)[""].ToCommand().iOptParam == COMMAND_OPTPARAM_TREE)
+								iOptParam = (intptr_t)&vecSplit;
+
+							if (!(*treePointer)[""].ToCommand().pCommand(vecArgs, breakout, iOptParam))
 								printf_yellow("Invalid argument.\n");
 							break;
 						}
@@ -1272,7 +1303,13 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 						for (size_t i = iDepth + 1; i < vecSplit.size(); i++)
 							vecArgs.push_back(vecSplit[i]);
 
-						if (!((*treePointer)[vecSplit[iDepth]].ToCommand().pCommand(vecArgs, breakout, (*treePointer)[vecSplit[iDepth]].ToCommand().iOptParam)))
+						intptr_t iOptParam = NULL;
+						if ((*treePointer)[vecSplit[iDepth]].ToCommand().iOptParam == COMMAND_OPTPARAM_ROOTNAME)
+							iOptParam = (intptr_t)&vecSplit[0];
+						else if ((*treePointer)[vecSplit[iDepth]].ToCommand().iOptParam == COMMAND_OPTPARAM_TREE)
+							iOptParam = (intptr_t)&vecSplit;
+
+						if (!((*treePointer)[vecSplit[iDepth]].ToCommand().pCommand(vecArgs, breakout, iOptParam)))
 							printf_yellow("Invalid argument.\n");
 						break;
 					}

--- a/modules/console_new.cpp
+++ b/modules/console_new.cpp
@@ -212,37 +212,37 @@ bool ConsoleCommandFixupThingsClear(std::vector<std::string> args, int iBreakout
 			if (++i >= args.size())
 				return false;
 
-			if (args[i] == "plane") {
+			if (args[i] == "plane" || args[i] == "planes") {
 				DeleteAllPlanes_SC2K1996();
 				continue;
-			} else if (args[i] == "helicopter") {
+			} else if (args[i] == "helicopter" || args[i] == "helicopters") {
 				DeleteAllCopters_SC2K1996();
 				continue;
-			} else if (args[i] == "cargoship") {
+			} else if (args[i] == "cargoship" || args[i] == "cargoships") {
 				DeleteAllShips_SC2K1996();
 				continue;
-			} else if (args[i] == "sailboat") {
+			} else if (args[i] == "sailboat" || args[i] == "sailboats") {
 				DeleteAllSailboats_SC2K1996();
 				continue;
-			} else if (args[i] == "train") {
+			} else if (args[i] == "train" || args[i] == "trains") {
 				DeleteAllTrains_SC2K1996();
 				continue;
-			} else if (args[i] == "maxisman") {
+			} else if (args[i] == "maxisman" || args[i] == "maxismen") {
 				DeleteAllMaxisMen_SC2K1996();
 				continue;
-			} else if (args[i] == "monster") {
+			} else if (args[i] == "monster" || args[i] == "monsters") {
 				DeleteAllMonsters_SC2K1996();
 				continue;
-			} else if (args[i] == "tornado") {
+			} else if (args[i] == "tornado" || args[i] == "tornadoes") {
 				DeleteAllTornadoes_SC2K1996();
 				continue;
-			} else if (args[i] == "policedeploy") {
+			} else if (args[i] == "policedeploy" || args[i] == "policedeploys" || args[i] == "police") {
 				DeleteAllPoliceDeploys_SC2K1996();
 				continue;
-			} else if (args[i] == "firedeploy") {
+			} else if (args[i] == "firedeploy" || args[i] == "firedeploys" || args[i] == "firefighters") {
 				DeleteAllFireDeploys_SC2K1996();
 				continue;
-			} else if (args[i] == "militarydeploy") {
+			} else if (args[i] == "militarydeploy" || args[i] == "militarydeploys" || args[i] == "tanks") {
 				DeleteAllMilitaryDeploys_SC2K1996();
 				continue;
 			} else

--- a/modules/console_new.cpp
+++ b/modules/console_new.cpp
@@ -48,7 +48,7 @@ console::CommandTree treeConsoleCommands;
 void PrintAlignedStringMap(std::map<std::string, std::string> mapStr, int iPrefixSpaces = 3) {
 	std::map<std::string, std::string> mapOutput;
 	std::string strPrefixSpaces(iPrefixSpaces, ' ');
-	int iLeftAlign = 0;
+	size_t iLeftAlign = 0;
 
 	for (auto s : mapStr) {
 		mapOutput[s.first] = s.second;
@@ -60,7 +60,7 @@ void PrintAlignedStringMap(std::map<std::string, std::string> mapStr, int iPrefi
 		printf("%s%s%s%s\n", strPrefixSpaces.c_str(), s.first.c_str(), std::string(3 + iLeftAlign - s.first.size(), ' ').c_str(), s.second.c_str());
 }
 
-bool ConsoleCommandRunLua(std::vector<std::string> args, int iBreakoutState) {
+bool ConsoleCommandRunLua(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
 	if (iBreakoutState == BREAKOUT_QUESTION) {
 		PrintAlignedStringMap(
 			{
@@ -105,7 +105,218 @@ bool ConsoleCommandRunLua(std::vector<std::string> args, int iBreakoutState) {
 	return true;
 }
 
-bool ConsoleCommandShowDebug(std::vector<std::string> args, int iBreakoutState) {
+static BYTE AttemptSafeReadByte(BYTE* address) {
+	__try {
+		return *address;
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+		ConsoleLog(LOG_ERROR, "CORE: Segmentation fault caught. Don't do that again.\n");
+		throw std::out_of_range("segfault");
+		return 0;
+	}
+}
+
+static WORD AttemptSafeReadWord(WORD* address) {
+	__try {
+		return *address;
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+		ConsoleLog(LOG_ERROR, "CORE: Segmentation fault caught. Don't do that again.\n");
+		throw std::out_of_range("segfault");
+		return 0;
+	}
+}
+
+static DWORD AttemptSafeReadDword(DWORD* address) {
+	__try {
+		return *address;
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+		ConsoleLog(LOG_ERROR, "CORE: Segmentation fault caught. Don't do that again.\n");
+		throw std::out_of_range("segfault");
+		return 0;
+	}
+}
+
+static uint64_t AttemptSafeReadQword(uint64_t* address) {
+	__try {
+		return *address;
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+		ConsoleLog(LOG_ERROR, "CORE: Segmentation fault caught. Don't do that again.\n");
+		throw std::out_of_range("segfault");
+		return 0;
+	}
+}
+
+static void AttemptSafeMemcpy(BYTE* dest, BYTE* src, size_t bytes) {
+	__try {
+		while (bytes--)
+			*dest++ = *src++;
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+		ConsoleLog(LOG_ERROR, "CORE: Segmentation fault caught. Don't do that again.\n");
+		throw std::out_of_range("segfault");
+		return;
+	}
+}
+
+bool ConsoleCommandShowMemory(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	DWORD dwAddress = NULL;
+	int iElementsCount = 1;
+	bool bAddressScanned = false;
+
+	BYTE b;
+	WORD w;
+	DWORD dw;
+	uint64_t qw;
+
+	// iOptParam is the element size (+1 for floating point when size == 4 or 8)
+	bool bFloat = (iOptParam == 5 || iOptParam == 9);
+	if (bFloat)
+		iOptParam--;
+
+	if (dwDetectedVersion != VERSION_SC2K_1996) {
+		printf_yellow("Command only available when attached to 1996 Special Edition.\n");
+		return true;
+	}
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap(
+			{
+				{"<address>", "Address to examine in hexadecimal"},
+				{"[count <count>]", "Number of elements to show (default 1)"},
+			});
+		bDontClearNextCommand = true;
+		return true;
+	}
+
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	if (args.size() == 0)
+		return false;
+
+	// Parse arguments
+	for (size_t i = 0; i < args.size(); i++) {
+		// [count <count>]
+		if (args[i] == "count") {
+			if (++i >= args.size())
+				return false;
+
+			if (!sscanf_s(args[i].c_str(), "%u", &iElementsCount))
+				return false;
+
+			continue;
+		}
+
+		// <address>
+		if (!bAddressScanned && sscanf_s(args[i].c_str(), "%X", &dwAddress)) {
+			bAddressScanned = true;
+			continue;
+		}
+
+		// Invalid arugment, bail out
+		return false;
+	}
+
+	// Do some quick sanity checking
+	if (iElementsCount < 1 || !dwAddress)
+		return false;
+
+	try {
+		if (iElementsCount == 1) {
+			printf("0x%08X: ", dwAddress);
+			switch (iOptParam) {
+			case 1:
+				b = AttemptSafeReadByte((BYTE*)dwAddress);
+				printf("(byte) 0x%02X / %d\n", b, b);
+				break;
+			case 2:
+				w = AttemptSafeReadWord((WORD*)dwAddress);
+				printf("(word) 0x%04X / %d\n", w, w);
+				break;
+			case 4:
+				dw = AttemptSafeReadDword((DWORD*)dwAddress);
+				if (bFloat)
+					printf("(float) %f\n", *(float*)&dw);
+				else
+					printf("(dword) 0x%08X / %d\n", dw, dw);
+				break;
+			case 8:
+				qw = AttemptSafeReadQword((uint64_t*)dwAddress);
+				if (bFloat)
+					printf("(double) %lf\n", *(double*)&qw);
+				else
+					printf("(qword) 0x%016llX / %lld\n", qw, qw);
+				break;
+			}
+		} else {
+			while (iElementsCount > 0) {
+				printf("0x%08X:", dwAddress);
+				size_t uNextElements = (iElementsCount * iOptParam > 16 ? 16 / iOptParam : iElementsCount);
+				iElementsCount -= 16 / iOptParam;
+
+				BYTE buf[16];
+				AttemptSafeMemcpy(buf, (BYTE*)dwAddress, 16);
+				for (int i = 0; i < uNextElements; i++) {
+					switch (iOptParam) {
+					case 1:
+						printf(" %02X", buf[i]);
+						break;
+					case 2:
+						printf(" %04X", *(WORD*)&buf[i * iOptParam]);
+						break;
+					case 4:
+						if (bFloat)
+							printf(" %f", *(float*)&buf[i * iOptParam]);
+						else
+							printf(" %08X", *(DWORD*)&buf[i * iOptParam]);
+						break;
+					case 8:
+						if (bFloat)
+							printf(" %lf", *(double*)&buf[i * iOptParam]);
+						else
+							printf(" %016llX", *(uint64_t*)&buf[i * iOptParam]);
+						break;
+					}
+				}
+				printf("\n");
+				dwAddress += 16;
+			}
+		}
+	}
+	catch (...) {
+		return true;
+	}
+
+	return true;
+}
+
+bool ConsoleCommandShowMemoryByte(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	return ConsoleCommandShowMemory(args, iBreakoutState, 1);
+}
+
+bool ConsoleCommandShowMemoryWord(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	return ConsoleCommandShowMemory(args, iBreakoutState, 2);
+}
+
+bool ConsoleCommandShowMemoryDword(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	return ConsoleCommandShowMemory(args, iBreakoutState, 4);
+}
+
+bool ConsoleCommandShowMemoryQword(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	return ConsoleCommandShowMemory(args, iBreakoutState, 8);
+}
+
+bool ConsoleCommandShowMemoryFloat(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	return ConsoleCommandShowMemory(args, iBreakoutState, 5);
+}
+
+bool ConsoleCommandShowMemoryDouble(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	return ConsoleCommandShowMemory(args, iBreakoutState, 9);
+}
+
+bool ConsoleCommandShowDebug(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
 	// No arguments allowed
 	if (iBreakoutState == BREAKOUT_QUESTION) {
 		bDontClearNextCommand = true;
@@ -147,7 +358,7 @@ bool ConsoleCommandShowDebug(std::vector<std::string> args, int iBreakoutState) 
 	return true;
 }
 
-bool ConsoleCommandShowVersion(std::vector<std::string> args, int iBreakoutState) {
+bool ConsoleCommandShowVersion(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
 	std::string strProgramName = "SimCity 2000";
 	std::string strProgramVersion = "unknown";
 
@@ -200,7 +411,7 @@ bool ConsoleCommandShowVersion(std::vector<std::string> args, int iBreakoutState
 		"Plugin loaded at 0x%08X\n\n"
 
 		"This program includes code from the following projects:\n"
-		"  %s is (c) 1994-2025 Lua.org, PUC-Rio; made available under the MIT License\n"
+		"  Lua is (c) 1994-2025 Lua.org, PUC-Rio; made available under the MIT License\n"
 		"  FluidSynth is (c) FluidSynth; made available under the LGPL 2.1 license\n\n"
 
 		"Licenses for third-party code can be found in the sc2kfix repository and distribution under\n"
@@ -213,8 +424,7 @@ bool ConsoleCommandShowVersion(std::vector<std::string> args, int iBreakoutState
 		strProgramName.c_str(),
 		strProgramVersion.c_str(),
 		LUA_VERSION,
-		(DWORD)hSC2KFixModule,
-		LUA_VERSION
+		(DWORD)hSC2KFixModule
 	);
 
 	return true;
@@ -225,6 +435,13 @@ void NewConsoleInitializeCommands(console::CommandTree& treeCommands) {
 	treeCommands["run"]["lua"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandRunLua, "Run Lua REPL or scripts");
 	treeCommands["show"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Display various game and plugin information");
 	treeCommands["show"]["debug"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowDebug, "Display enabled debugging options");
+	treeCommands["show"]["memory"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Display memory contents");
+	treeCommands["show"]["memory"]["byte"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMemoryByte, "Display byte-sized elements");
+	treeCommands["show"]["memory"]["word"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMemoryWord, "Display word-sized elements");
+	treeCommands["show"]["memory"]["dword"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMemoryDword, "Display double word-sized elements");
+	treeCommands["show"]["memory"]["qword"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMemoryQword, "Display quad word-sized elements");
+	treeCommands["show"]["memory"]["float"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMemoryFloat, "Display single precision floating point elements");
+	treeCommands["show"]["memory"]["double"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMemoryDouble, "Display double precision floating point elements");
 	treeCommands["show"]["version"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowVersion, "Show sc2kfix and library version info");
 }
 
@@ -310,7 +527,7 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 		debug_printf("vecSplit.size: %d\n", vecSplit.size());
 
 		if ((bDoJuniperStyle && breakout == BREAKOUT_SPACE) || breakout == BREAKOUT_QUESTION || breakout == BREAKOUT_TAB) {
-			int iDepth = 0;
+			size_t iDepth = 0;
 			console::CommandTree* treePointer = &treeConsoleCommands;
 			while (iDepth < vecSplit.size()) {
 				if (treePointer->hasKey(vecSplit[iDepth])) {
@@ -387,11 +604,11 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 		}
 
 		if (breakout == BREAKOUT_QUESTION || breakout == BREAKOUT_TAB || (breakout == BREAKOUT_SPACE)) {
-			int iDepth = 0;
+			size_t iDepth = 0;
 			console::CommandTree* treePointer = &treeConsoleCommands;
 
 			std::map<std::string, std::string> mapOutput;
-			int iLongestCommand = 0;
+			size_t iLongestCommand = 0;
 
 			if (vecSplit.size() == 0) {
 				for (auto s : treePointer->ObjectRange()) {
@@ -486,7 +703,7 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 				strCommand.erase(std::find_if(strCommand.rbegin(), strCommand.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), strCommand.end());
 
 				if (breakout == BREAKOUT_TAB || breakout == BREAKOUT_SPACE) {
-					int i = 0;
+					size_t i = 0;
 					std::map<std::string, std::string> mapSort = mapOutput;
 
 					for (auto s : mapSort) {
@@ -518,7 +735,7 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 					//printf("shortest command: %d\n", i);
 
 					bool local_breakout = false;
-					int j;
+					size_t j;
 					for (j = vecSplit[iDepth].size(); j < i; j++) {
 						char c = mapOutput.begin()->first[j];
 						for (auto s : mapOutput) {
@@ -575,7 +792,7 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 
 			strCommand.erase(std::find_if(strCommand.rbegin(), strCommand.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), strCommand.end());
 
-			int iDepth = 0;
+			size_t iDepth = 0;
 			console::CommandTree* treePointer = &treeConsoleCommands;
 			while (iDepth < vecSplit.size()) {
 				if (treePointer->hasKey(vecSplit[iDepth])) {
@@ -601,10 +818,10 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 							}
 
 							std::vector<std::string> vecArgs;
-							for (int i = iDepth + 1; i < vecSplit.size(); i++)
+							for (size_t i = iDepth + 1; i < vecSplit.size(); i++)
 								vecArgs.push_back(vecSplit[i]);
 
-							if (!(*treePointer)[""].ToCommand().pCommand(vecArgs, breakout))
+							if (!(*treePointer)[""].ToCommand().pCommand(vecArgs, breakout, 0))
 								printf_yellow("Invalid argument.\n");
 							break;
 						}
@@ -615,10 +832,10 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 					else if ((*treePointer)[vecSplit[iDepth]].ObjectType() == console::CommandTree::Class::Command) {
 						debug_printf("%d: found command\n", iDepth);
 						std::vector<std::string> vecArgs;
-						for (int i = iDepth + 1; i < vecSplit.size(); i++)
+						for (size_t i = iDepth + 1; i < vecSplit.size(); i++)
 							vecArgs.push_back(vecSplit[i]);
 
-						if (!((*treePointer)[vecSplit[iDepth]].ToCommand().pCommand(vecArgs, breakout)))
+						if (!((*treePointer)[vecSplit[iDepth]].ToCommand().pCommand(vecArgs, breakout, 0)))
 							printf_yellow("Invalid argument.\n");
 						break;
 					}

--- a/modules/console_new.cpp
+++ b/modules/console_new.cpp
@@ -41,10 +41,10 @@ void drop_args(...) {
 	return;
 }
 
-bool bConsoleInLuaREPL = false;
-bool bConsoleElevatedMode = false;
-bool bConsoleKeepCommandBuffer = false;
-console::CommandTree treeConsoleCommands;
+HOOKEXT bool bConsoleInLuaREPL = false;
+HOOKEXT bool bConsoleElevatedMode = false;
+HOOKEXT bool bConsoleKeepCommandBuffer = false;
+HOOKEXT_CPP console::CommandTree treeConsoleCommands;
 
 static BYTE AttemptSafeReadByte(BYTE* address) {
 	__try {
@@ -123,7 +123,7 @@ static const char* GetMidiDeviceTechnologyString(WORD wTechnology) {
 	}
 }
 
-void PrintAlignedStringMap(std::map<std::string, std::string> mapStr, int iPrefixSpaces = 3) {
+HOOKEXT_CPP void PrintAlignedStringMap(std::map<std::string, std::string> mapStr, int iPrefixSpaces) {
 	std::map<std::string, std::string> mapOutput;
 	std::string strPrefixSpaces(iPrefixSpaces, ' ');
 	size_t iLeftAlign = 0;

--- a/modules/console_new.cpp
+++ b/modules/console_new.cpp
@@ -42,8 +42,8 @@ void drop_args(...) {
 }
 
 bool bConsoleInLuaREPL = false;
-bool bConsoleUndocumentedMode = false;
-bool bDontClearNextCommand = false;
+bool bConsoleElevatedMode = false;
+bool bConsoleKeepCommandBuffer = false;
 console::CommandTree treeConsoleCommands;
 
 static BYTE AttemptSafeReadByte(BYTE* address) {
@@ -142,7 +142,7 @@ bool ConsoleCommandClear(std::vector<std::string> args, int iBreakoutState, intp
 	// No arguments allowed
 	if (iBreakoutState == BREAKOUT_QUESTION) {
 		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return true;
 	}
 	if (iBreakoutState != BREAKOUT_RETURN)
@@ -154,11 +154,89 @@ bool ConsoleCommandClear(std::vector<std::string> args, int iBreakoutState, intp
 	return true;
 }
 
+#define SETDEBUGOP(keyword, var, description) \
+	if (args[i] == keyword || bSetAll) { \
+		var ## _debug = dwOperation; \
+		printf("%sabled " description " debugging.\n", (dwOperation ? "En" : "Dis")); \
+		bSuccess = true; \
+	}
+
+bool ConsoleCommandSetDebug(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	DWORD dwOperation = DEBUG_FLAGS_NONE;
+	bool bSetAll = false;
+
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap(
+			{
+				{"guzzardo", "Enable/disable cousin Vinnie debugging"},
+				{"mci", "Enable/disable MCI debugging"},
+				{"military", "Enable/disable military base algorithm debugging"},
+				{"mischook", "Enable/disable miscellaneous debugging"},
+				{"modloader", "Enable/disable native code mod loader debugging"},
+				{"mus", "Enable/disable music engine debugging"},
+				{"registry", "Enable/disable registry override hooks debugging"},
+				{"sc2x", "Enable/disable SC2X format and load/save debugging"},
+				{"snd", "Enable/disable sound hook debugging"},
+				{"sprite", "Enable/disable sprite and tileset hook debugging"},
+				{"timer", "Enable/disable timer hook debugging"},
+				{"update", "Enable/disable update notifier debugging"}
+			});
+		bConsoleKeepCommandBuffer = true;
+		return true;
+	}
+
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	std::string& strRootName = *((std::string*)iOptParam);
+	if (strRootName == "set")
+		dwOperation = DEBUG_FLAGS_EVERYTHING;
+	else
+		dwOperation = DEBUG_FLAGS_NONE;
+
+	// Arguments are required for this command
+	if (args.size() == 0) {
+		bConsoleKeepCommandBuffer = true;
+		return false;
+	}
+
+	// Parse arguments
+	// To save on typing this one works a bit differently than other commands. A better example
+	// of how to parse arguments would be the "show memory" or "show microsim" commands.
+	for (size_t i = 0; i < args.size(); i++) {
+		bool bSuccess = false;
+		if (args[i] == "all") {
+			bSetAll = true;
+			i = args.size();
+			bSuccess = true;
+		}
+
+		SETDEBUGOP("guzzardo", guzzardo, "cousin Vinnie")
+		SETDEBUGOP("mci", mci, "MCI")
+		SETDEBUGOP("military", military, "military base algorithm")
+		SETDEBUGOP("mischook", mischook, "miscellaneous")
+		SETDEBUGOP("modloader", modloader, "native code mod loader")
+		SETDEBUGOP("mus", mus, "music engine")
+		SETDEBUGOP("registry", registry, "registry override hooks")
+		SETDEBUGOP("sc2x", sc2x, "SC2X format and load/save")
+		SETDEBUGOP("snd", snd, "sound hook")
+		SETDEBUGOP("sprite", sprite, "sprite and tileset hook")
+		SETDEBUGOP("timer", timer, "timer hook")
+		SETDEBUGOP("update", updatenotifier, "update notifier")
+
+		// Invalid arugment, bail out
+		if (!bSuccess)
+			return false;
+	}
+
+	return true;
+}
+
 bool ConsoleCommandSetUndocumented(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
 	// No arguments allowed
 	if (iBreakoutState == BREAKOUT_QUESTION) {
 		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return true;
 	}
 	if (iBreakoutState != BREAKOUT_RETURN)
@@ -166,9 +244,9 @@ bool ConsoleCommandSetUndocumented(std::vector<std::string> args, int iBreakoutS
 
 	std::string& strRootName = *((std::string*)iOptParam);
 	if (strRootName == "set")
-		bConsoleUndocumentedMode = true;
+		bConsoleElevatedMode = true;
 	else
-		bConsoleUndocumentedMode = false;
+		bConsoleElevatedMode = false;
 	return true;
 }
 
@@ -176,7 +254,7 @@ bool ConsoleCommandShowAudioBuffers(std::vector<std::string> args, int iBreakout
 	// No arguments allowed
 	if (iBreakoutState == BREAKOUT_QUESTION) {
 		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return true;
 	}
 	if (iBreakoutState != BREAKOUT_RETURN)
@@ -192,7 +270,7 @@ bool ConsoleCommandShowAudioEngine(std::vector<std::string> args, int iBreakoutS
 	// No arguments allowed
 	if (iBreakoutState == BREAKOUT_QUESTION) {
 		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return true;
 	}
 	if (iBreakoutState != BREAKOUT_RETURN)
@@ -209,7 +287,7 @@ bool ConsoleCommandShowAudioMidi(std::vector<std::string> args, int iBreakoutSta
 	// No arguments allowed
 	if (iBreakoutState == BREAKOUT_QUESTION) {
 		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return true;
 	}
 	if (iBreakoutState != BREAKOUT_RETURN)
@@ -233,7 +311,7 @@ bool ConsoleCommandShowAudioSongs(std::vector<std::string> args, int iBreakoutSt
 	// No arguments allowed
 	if (iBreakoutState == BREAKOUT_QUESTION) {
 		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return true;
 	}
 	if (iBreakoutState != BREAKOUT_RETURN)
@@ -254,7 +332,7 @@ bool ConsoleCommandRunLua(std::vector<std::string> args, int iBreakoutState, int
 				{"<[Enter]>", "Switches to the Lua REPL"},
 				{"<filename>", "Executes a file as a standalone Lua script"},
 			});
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return true;
 	}
 
@@ -296,7 +374,7 @@ bool ConsoleCommandRunTest(std::vector<std::string> args, int iBreakoutState, in
 	// No arguments allowed
 	if (iBreakoutState == BREAKOUT_QUESTION) {
 		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return true;
 	}
 	if (iBreakoutState != BREAKOUT_RETURN)
@@ -333,7 +411,7 @@ bool ConsoleCommandShowMemory(std::vector<std::string> args, int iBreakoutState,
 				{"[decimal]", "Display integers in decimal instead of hex"},
 				{"[octal]", "Display integers in octal instead of hex"},
 			});
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return true;
 	}
 
@@ -342,7 +420,7 @@ bool ConsoleCommandShowMemory(std::vector<std::string> args, int iBreakoutState,
 
 	// Arguments are required for this command
 	if (args.size() == 0) {
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return false;
 	}
 
@@ -548,7 +626,7 @@ bool ConsoleCommandShowMicrosim(std::vector<std::string> args, int iBreakoutStat
 				{"subway", "Display microsim data for subway stations"},
 				{"wind", "Display microsim data for wind power plants"},
 			});
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return true;
 	}
 
@@ -557,7 +635,7 @@ bool ConsoleCommandShowMicrosim(std::vector<std::string> args, int iBreakoutStat
 
 	// Arguments are required for this command
 	if (args.size() == 0) {
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return false;
 	}
 
@@ -675,7 +753,7 @@ bool ConsoleCommandShowMods(std::vector<std::string> args, int iBreakoutState, i
 				{"[lua]", "Only shows information about Lua mods"},
 				{"[native]", "Only shows information about native code mods"},
 			});
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return true;
 	}
 
@@ -745,7 +823,7 @@ bool ConsoleCommandShowDebug(std::vector<std::string> args, int iBreakoutState, 
 	// No arguments allowed
 	if (iBreakoutState == BREAKOUT_QUESTION) {
 		PrintAlignedStringMap({{"<[Enter]>", "Execute this command"}});
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return true;
 	}
 	if (iBreakoutState != BREAKOUT_RETURN)
@@ -788,7 +866,7 @@ bool ConsoleCommandShowSettingsJson(std::vector<std::string> args, int iBreakout
 	// No arguments allowed
 	if (iBreakoutState == BREAKOUT_QUESTION) {
 		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return true;
 	}
 	if (iBreakoutState != BREAKOUT_RETURN)
@@ -806,7 +884,7 @@ bool ConsoleCommandShowVersion(std::vector<std::string> args, int iBreakoutState
 	// No arguments allowed
 	if (iBreakoutState == BREAKOUT_QUESTION) {
 		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
-		bDontClearNextCommand = true;
+		bConsoleKeepCommandBuffer = true;
 		return true;
 	}
 	if (iBreakoutState != BREAKOUT_RETURN)
@@ -878,6 +956,7 @@ void NewConsoleInitializeCommands(console::CommandTree& treeCommands) {
 	treeCommands["run"]["lua"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandRunLua, "Run Lua REPL or scripts");
 	treeCommands["run"]["test"] = ConsoleCommand(COMMAND_TYPE_UNDOCUMENTED, ConsoleCommandRunTest, "Test command");
 	treeCommands["set"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Modify game and plugin behaviour");
+	treeCommands["set"]["debug"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandSetDebug, "Enable/disable debugging options", COMMAND_OPTPARAM_ROOTNAME);
 	treeCommands["set"]["undocumented"] = ConsoleCommand(COMMAND_TYPE_UNDOCUMENTED, ConsoleCommandSetUndocumented, "Enable/disable display of special commands", COMMAND_OPTPARAM_ROOTNAME);
 	treeCommands["show"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Display various game and plugin information");
 	treeCommands["show"]["audio"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Show audio engine info");
@@ -910,7 +989,7 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 	bool bFullCommand = false;
 	bool bDoneQuestionOut = false;
 	bool bDoJuniperStyle = true;
-	bDontClearNextCommand = false;
+	bConsoleKeepCommandBuffer = false;
 
 	// Initialize the console
 	Sleep(200);
@@ -919,7 +998,7 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 
 	// HIC SUNT DRACONES
 	while (true) {
-		if (bConsoleUndocumentedMode)
+		if (bConsoleElevatedMode)
 			printf(VT100_COLOUR_BRIGHT_WHITE "sc2kfix# " VT100_DEFAULT "%s", strCommand.c_str());
 		else
 			printf(VT100_COLOUR_BRIGHT_WHITE "sc2kfix> " VT100_DEFAULT "%s", strCommand.c_str());
@@ -1135,7 +1214,7 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 					if ((*treePointer)[s.first].ObjectType() == console::CommandTree::Class::Command) {
 						if (!string_starts_with(s2, vecSplit[iDepth].c_str()))
 							continue;
-						if (!bConsoleUndocumentedMode && s.second.ToCommand().iType == COMMAND_TYPE_UNDOCUMENTED ||
+						if (!bConsoleElevatedMode && s.second.ToCommand().iType == COMMAND_TYPE_UNDOCUMENTED ||
 							s.second.ToCommand().iType == COMMAND_TYPE_HIDDEN)
 							continue;
 
@@ -1320,10 +1399,10 @@ DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {
 				}
 			}
 
-			if (!bDontClearNextCommand && !bDoneQuestionOut)
+			if (!bConsoleKeepCommandBuffer && !bDoneQuestionOut)
 				strCommand = "";
 
-			bDontClearNextCommand = false;
+			bConsoleKeepCommandBuffer = false;
 		}
 	}
 }

--- a/modules/console_new.cpp
+++ b/modules/console_new.cpp
@@ -32,11 +32,6 @@
 #define debug_printf printf
 #endif
 
-#define printf_red(s, ...) printf(VT100_COLOUR_RED s VT100_DEFAULT, __VA_ARGS__)
-#define printf_lightred(s, ...) printf(VT100_COLOUR_BRIGHT_RED s VT100_DEFAULT, __VA_ARGS__)
-#define printf_yellow(s, ...) printf(VT100_COLOUR_YELLOW s VT100_DEFAULT, __VA_ARGS__)
-#define printf_lightblue(s, ...) printf(VT100_COLOUR_BRIGHT_BLUE s VT100_DEFAULT, __VA_ARGS__)
-
 void drop_args(...) {
 	return;
 }

--- a/modules/console_new.cpp
+++ b/modules/console_new.cpp
@@ -101,6 +101,27 @@ static void AttemptSafeMemcpy(BYTE* dest, BYTE* src, size_t bytes) {
 	}
 }
 
+static const char* GetMidiDeviceTechnologyString(WORD wTechnology) {
+	switch (wTechnology) {
+	case MOD_MIDIPORT:
+		return "Hardware MIDI port";
+	case MOD_SYNTH:
+		return "Hardware synthesizer";
+	case MOD_SQSYNTH:
+		return "Square wave synthesizer";
+	case MOD_FMSYNTH:
+		return "FM synthesizer";
+	case MOD_MAPPER:
+		return "Microsoft MIDI mapper";
+	case MOD_WAVETABLE:
+		return "Wavetable synthesizer";
+	case MOD_SWSYNTH:
+		return "Software synthesizer";
+	default:
+		return "Unknown";
+	}
+}
+
 void PrintAlignedStringMap(std::map<std::string, std::string> mapStr, int iPrefixSpaces = 3) {
 	std::map<std::string, std::string> mapOutput;
 	std::string strPrefixSpaces(iPrefixSpaces, ' ');
@@ -129,6 +150,81 @@ bool ConsoleCommandClear(std::vector<std::string> args, int iBreakoutState, intp
 	// It is the year 2026. Don't let anyone tell you Windows doesn't support VT100 control codes.
 	printf("\x1b[2J\x1b[0;0H");
 
+	return true;
+}
+
+bool ConsoleCommandShowAudioBuffers(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	// No arguments allowed
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
+		bDontClearNextCommand = true;
+		return true;
+	}
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	int i = 0;
+	for (const auto& iter : mapSoundBuffers)
+		printf("  %i: <0x%08X>   %i.wav   (reloads: %i)\n", i++, iter.first, iter.second.iSoundID, iter.second.iReloadCount);
+	return true;
+}
+
+bool ConsoleCommandShowAudioEngine(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	// No arguments allowed
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
+		bDontClearNextCommand = true;
+		return true;
+	}
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	printf(
+		"Audio engine: %s\n"
+		"Music driver: %s\n",
+		"old", jsonSettingsCore["sc2kfix"]["audio"]["music_driver"].ToString().c_str());
+	return true;
+}
+
+bool ConsoleCommandShowAudioMidi(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	// No arguments allowed
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
+		bDontClearNextCommand = true;
+		return true;
+	}
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	printf("MIDI devices (max %u):\n", midiOutGetNumDevs());
+	int maxdevs = midiOutGetNumDevs();
+	for (int i = -1; i < maxdevs; i++) {
+		MIDIOUTCAPS moc;
+		midiOutGetDevCaps(i, &moc, sizeof(MIDIOUTCAPS));
+		printf(
+			"  Device %i:\n"
+			"    Product ID:   %04X:%04X\n"
+			"    Name:         %s\n"
+			"    Technology:   %s\n", i, moc.wMid, moc.wPid, moc.szPname, GetMidiDeviceTechnologyString(moc.wTechnology));
+	}
+	return true;
+}
+
+bool ConsoleCommandShowAudioSongs(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	// No arguments allowed
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
+		bDontClearNextCommand = true;
+		return true;
+	}
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	extern int iCurrentSong;
+	printf("Current playlist: ");
+	for (int i = 0; i < (int)vectorRandomSongIDs.size(); i++)
+		printf("%i%s ", vectorRandomSongIDs[i], (i == iCurrentSong ? "*" : ""));
+	printf("\n");
 	return true;
 }
 
@@ -174,6 +270,19 @@ bool ConsoleCommandRunLua(std::vector<std::string> args, int iBreakoutState, int
 		lua_close(L);
 	}
 	
+	return true;
+}
+
+bool ConsoleCommandRunTest(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	// No arguments allowed
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
+		bDontClearNextCommand = true;
+		return true;
+	}
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
 	return true;
 }
 
@@ -656,6 +765,21 @@ bool ConsoleCommandShowDebug(std::vector<std::string> args, int iBreakoutState, 
 	return true;
 }
 
+bool ConsoleCommandShowSettingsJson(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
+	// No arguments allowed
+	if (iBreakoutState == BREAKOUT_QUESTION) {
+		PrintAlignedStringMap({ {"<[Enter]>", "Execute this command"} });
+		bDontClearNextCommand = true;
+		return true;
+	}
+	if (iBreakoutState != BREAKOUT_RETURN)
+		return false;
+
+	printf("jsonSettingsCore:\n%s\n\n", jsonSettingsCore.dump().c_str());
+	printf("jsonSettingsMods:\n%s\n", jsonSettingsMods.dump().c_str());
+	return true;
+}
+
 bool ConsoleCommandShowVersion(std::vector<std::string> args, int iBreakoutState, intptr_t iOptParam) {
 	std::string strProgramName = "SimCity 2000";
 	std::string strProgramVersion = "unknown";
@@ -733,7 +857,13 @@ void NewConsoleInitializeCommands(console::CommandTree& treeCommands) {
 	treeCommands["clear"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandClear, "Clear the console");
 	treeCommands["run"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Run Lua REPL or scripts");
 	treeCommands["run"]["lua"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandRunLua, "Run Lua REPL or scripts");
+	treeCommands["run"]["test"] = ConsoleCommand(COMMAND_TYPE_UNDOCUMENTED, ConsoleCommandRunTest, "Test command");
 	treeCommands["show"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Display various game and plugin information");
+	treeCommands["show"]["audio"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Show audio engine info");
+	treeCommands["show"]["audio"]["buffers"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowAudioBuffers, "Dump loaded WAV buffer metadata");
+	treeCommands["show"]["audio"]["engine"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowAudioEngine, "Display audio engine information");
+	treeCommands["show"]["audio"]["midi"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowAudioMidi, "Dump all discovered MIDI devices");
+	treeCommands["show"]["audio"]["songs"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowAudioSongs, "Dump the current song playlist");
 	treeCommands["show"]["debug"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowDebug, "Display enabled debugging options");
 	treeCommands["show"]["memory"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Display memory contents");
 	treeCommands["show"]["memory"]["byte"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMemoryByte, "Display byte-sized elements");
@@ -744,7 +874,12 @@ void NewConsoleInitializeCommands(console::CommandTree& treeCommands) {
 	treeCommands["show"]["memory"]["double"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMemoryDouble, "Display double precision floating point elements");
 	treeCommands["show"]["microsim"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMicrosim, "Show microsim data");
 	treeCommands["show"]["mods"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowMods, "Show loaded mods");
-	treeCommands["show"]["version"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowVersion, "Show sc2kfix and library version info");
+	treeCommands["show"]["settings"][""] = ConsoleCommand(COMMAND_TYPE_BRANCH, NULL, "Show settings info");
+	treeCommands["show"]["settings"]["json"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowSettingsJson, "Dump JSON settings structure");
+	treeCommands["show"]["version"] = ConsoleCommand(COMMAND_TYPE_DOCUMENTED, ConsoleCommandShowVersion, "Show sc2kfix and library versions");
+
+	// Aliases
+	treeCommands["show"]["sound"] = treeCommands["show"]["audio"];
 }
 
 DWORD WINAPI NewConsoleThread(LPVOID lpParameter) {

--- a/modules/music.cpp
+++ b/modules/music.cpp
@@ -420,7 +420,7 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 	MCIERROR dwMCIError = NULL;
 
 	if (mus_debug & MUS_DEBUG_THREAD)
-		ConsoleLog(LOG_DEBUG, "MUS:  Starting music engine! Initial music driver set to \"%s\".\n", jsonSettingsCore["sc2kfix"]["audio"]["music_driver"].ToString());
+		ConsoleLog(LOG_DEBUG, "MUS:  Starting music engine! Initial music driver set to \"%s\".\n", jsonSettingsCore["sc2kfix"]["audio"]["music_driver"].ToString().c_str());
 	
 	while (GetMessage(&msg, NULL, 0, 0)) {
 		pSCApp = &pCSimcityAppThis;

--- a/modules/settings.cpp
+++ b/modules/settings.cpp
@@ -17,8 +17,8 @@
 
 static DWORD dwDummy;
 
-json::JSON jsonSettingsCore;
-json::JSON jsonSettingsMods;
+HOOKEXT_CPP json::JSON jsonSettingsCore;
+HOOKEXT_CPP json::JSON jsonSettingsMods;
 
 char szGamePath[MAX_PATH];
 

--- a/sc2kfix.vcxproj
+++ b/sc2kfix.vcxproj
@@ -75,6 +75,7 @@ const char* szSC2KFixBuildInfo = "$(UserName)@$(ComputerName)  $([System.DateTim
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="include\bc45xhelp.h" />
+    <ClInclude Include="include\commandtree.hpp" />
     <ClInclude Include="include\commonhelp.h" />
     <ClInclude Include="include\hooklists.h" />
     <ClInclude Include="include\json.hpp" />
@@ -158,6 +159,7 @@ const char* szSC2KFixBuildInfo = "$(UserName)@$(ComputerName)  $([System.DateTim
     <ClCompile Include="hooks\hook_querydialog.cpp" />
     <ClCompile Include="hooks\hook_sndPlaySound.cpp" />
     <ClCompile Include="hooks\hook_mmtimers.cpp" />
+    <ClCompile Include="modules\console_new.cpp" />
     <ClCompile Include="modules\game_graphics.cpp" />
     <ClCompile Include="modules\keybindings.cpp" />
     <ClCompile Include="modules\lua_glue.cpp" />

--- a/sc2kfix.vcxproj
+++ b/sc2kfix.vcxproj
@@ -151,7 +151,6 @@ const char* szSC2KFixBuildInfo = "$(UserName)@$(ComputerName)  $([System.DateTim
     <ClCompile Include="hooks\hook_tilegrowthorplacement.cpp" />
     <ClCompile Include="hooks\hook_toolbars.cpp" />
     <ClCompile Include="modules\common_remote_functions.cpp" />
-    <ClCompile Include="modules\console.cpp" />
     <ClCompile Include="buildinfo.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="hooks\hook_mciSendCommand.cpp" />

--- a/sc2kfix.vcxproj.filters
+++ b/sc2kfix.vcxproj.filters
@@ -263,9 +263,6 @@
     <ClCompile Include="hooks\hook_sndPlaySound.cpp">
       <Filter>Source Files\Hooks</Filter>
     </ClCompile>
-    <ClCompile Include="modules\console.cpp">
-      <Filter>Source Files\Modules</Filter>
-    </ClCompile>
     <ClCompile Include="hooks\hook_mmtimers.cpp">
       <Filter>Source Files\Hooks</Filter>
     </ClCompile>

--- a/sc2kfix.vcxproj.filters
+++ b/sc2kfix.vcxproj.filters
@@ -252,6 +252,9 @@
     <ClInclude Include="include\lua_glue.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\commandtree.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="hooks\hook_mciSendCommand.cpp">
@@ -474,6 +477,9 @@
       <Filter>Source Files\Modules</Filter>
     </ClCompile>
     <ClCompile Include="modules\scurk_objmove.cpp">
+      <Filter>Source Files\Modules</Filter>
+    </ClCompile>
+    <ClCompile Include="modules\console_new.cpp">
       <Filter>Source Files\Modules</Filter>
     </ClCompile>
   </ItemGroup>

--- a/utility.cpp
+++ b/utility.cpp
@@ -10,6 +10,7 @@
 #include <stdio.h>
 
 #include <sc2kfix.h>
+#include <commandtree.hpp>
 #include "resource.h"
 
 BOOL bFontsInitialized = FALSE;
@@ -498,6 +499,10 @@ HOOKEXT_CPP json::JSON json::JSON::Load(const string& str) {
 	return std::move(parse_next(str, offset));
 }
 
+console::CommandTree console::Object() {
+	return std::move(CommandTree::Make(CommandTree::Class::Object));
+}
+
 HOOKEXT_CPP json::JSON EncodeDWORDArray(DWORD* dwArray, size_t iCount, BOOL bBigEndian) {
 	json::JSON jsonArray = json::Array();
 	for (size_t i = 0; i < iCount; i++) {
@@ -572,4 +577,51 @@ HOOKEXT_CPP std::string string_format(const char* fmt, ...) {
 
 	va_end(args);
 	return str;
+}
+
+HOOKEXT_CPP bool string_split(std::string str, std::vector<std::string>& qargs) {
+	int len = str.length();
+	bool qot = false, sqot = false;
+	int arglen;
+	qargs.clear();
+
+	for (int i = 0; i < len; i++) {
+		int start = i;
+		if (str[i] == '\"')
+			qot = true;
+
+		else if (str[i] == '\'') sqot = true;
+
+		if (qot) {
+			i++;
+			start++;
+			while (i < len && str[i] != '\"')
+				i++;
+			if (i < len)
+				qot = false;
+			arglen = i - start;
+			i++;
+		}
+		else if (sqot) {
+			i++;
+			start++;
+			while (i < len && str[i] != '\'')
+				i++;
+			if (i < len)
+				sqot = false;
+			arglen = i - start;
+			i++;
+		}
+		else {
+			while (i < len && str[i] != ' ')
+				i++;
+			arglen = i - start;
+		}
+		qargs.push_back(str.substr(start, arglen));
+	}
+
+	// Return false if there's a syntax error, true if not
+	if (qot || sqot)
+		return false;
+	return true;
 }


### PR DESCRIPTION
The console CLI is a lot cleaner to work with and extend. It supports better contextual help and autocomplete when typing, much like the Junos CLI. The command structure is also exported to native code mods so they can extend it; `testmod` has been updated to showcase this.

The code still needs to be commented a bit and there's probably a few things I could clean up, but it works and the stuff that matters has been reimplemented cleanly.