### PR TITLE
Tooltip storage and clean-up

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -53,6 +53,8 @@ int iForcedBits = 0;
 std::random_device rdRandomDevice;
 std::mt19937 mtMersenneTwister(rdRandomDevice());
 
+std::vector<tooltip_store_t> storedToolTips;
+
 #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
 #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
 #endif

--- a/hooks/hook_sc2k1996_miscellaneous.cpp
+++ b/hooks/hook_sc2k1996_miscellaneous.cpp
@@ -882,67 +882,69 @@ std::vector<hook_function_t> stHooks_Hook_OnNewCity_Before;
 static BOOL CALLBACK Hook_NewCityDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam) {
 	switch (message) {
 	case WM_INITDIALOG:
+		DestroyStoredTooltips(storedToolTips, hwndDlg);
+
 		// Difficulty selection tooltips
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, 109),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, 109),
 			"Start a game on Easy difficulty.\n"
 			"Modifiers:\n"
 			" - $20,000 starting cash\n"
 			" - Slightly increased industrial demand\n"
 			" - Four months before disasters can occur");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, 1001),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, 1001),
 			"Start a game on Easy difficulty.\n"
 			"Modifiers:\n"
 			" - $20,000 starting cash\n"
 			" - Slightly increased industrial demand\n"
 			" - Four months before disasters can occur");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, 110),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, 110),
 			"Start a game on Medium difficulty.\n"
 			"Modifiers:\n"
 			" - $10,000 starting cash\n"
 			" - Baseline industrial demand\n"
 			" - Two months before disasters can occur");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, 1002),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, 1002),
 			"Start a game on Medium difficulty.\n"
 			"Modifiers:\n"
 			" - $10,000 starting cash\n"
 			" - Baseline industrial demand\n"
 			" - Two months before disasters can occur");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, 111),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, 111),
 			"Start a game on Hard difficulty.\n"
 			"Modifiers:\n"
 			" - $10,000 bond at 3% APR\n"
 			" - Slightly decreased industrial demand\n"
 			" - One month before disasters can occur");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, 1003),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, 1003),
 			"Start a game on Hard difficulty.\n"
 			"Modifiers:\n"
 			" - $10,000 bond at 3% APR\n"
 			" - Slightly decreased industrial demand\n"
 			" - One month before disasters can occur");
 
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, 1010),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, 1010),
 			"Hover over a date to see the difference between starting years.");
 
 		// Year selection tooltips
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, 104),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, 104),
 			"Start the game in 1900.\n"
 			"Modifiers:\n"
 			" - No forced unlocks.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, 105),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, 105),
 			"Start the game in 1950.\n"
 			"Modifiers:\n"
 			" - Subways, buses, highways, and airports unlocked.\n"
 			" - Water treatment plants unlocked.\n"
 			" - 50% chance of natural gas power plants being unlocked.\n"
 			" - 5% chance of nuclear power plants being unlocked.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, 106),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, 106),
 			"Start the game in 2000.\n"
 			"Modifiers:\n"
 			" - Subways, buses, highways, and airports unlocked.\n"
 			" - Water treatment and desalination plants unlocked.\n"
 			" - Natural gas, nuclear, wind, and solar power plants unlocked.\n"
 			" - 50% chance of Plymouth arcologies being unlocked.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, 107),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, 107),
 			"Start the game in 2050.\n"
 			"Modifiers:\n"
 			" - Subways, buses, highways, and airports unlocked.\n"
@@ -962,6 +964,8 @@ static BOOL CALLBACK Hook_NewCityDialogProc(HWND hwndDlg, UINT message, WPARAM w
 			strcpy_s(szTempMayorName, 24, jsonSettingsCore[C_SIMCITY2000][S_SIM_REG][I_SIM_REG_MAYORNAME].ToString().c_str());
 
 		SetXLABEntry(0, szTempMayorName);
+
+		DestroyStoredTooltips(storedToolTips, hwndDlg);
 
 		// XXX - this should probably be moved to a separate proper hook into the game itself
 		for (const auto& hook : stHooks_Hook_OnNewCity_Before) {

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -384,9 +384,18 @@ BOOL L_IsDirectoryPathValid(const char *pStr);
 
 // Utility functions
 
+typedef struct {
+	HWND hParent;
+	HWND hControl;
+	HWND hToolTip;
+} tooltip_store_t;
+
+extern std::vector<tooltip_store_t> storedToolTips;
+
 void InitializeFonts(void);
 HOOKEXT void CenterDialogBox(HWND hwndDlg);
-HOOKEXT HWND CreateTooltip(HWND hDlg, HWND hControl, const char* szText);
+HOOKEXT void StoreTooltip(std::vector<tooltip_store_t> &tt_s, HWND hParent, HWND hControl, const char *szText);
+HOOKEXT void DestroyStoredTooltips(std::vector<tooltip_store_t> &tt_s, HWND hParent);
 HOOKEXT const char* HexPls(UINT uNumber, int width);
 HOOKEXT const char* FormatVersion(int iMajor, int iMinor, int iPatch);
 HOOKEXT_CPP std::string WordWrap(std::string strInput, size_t iMaxWidth, size_t iIndentWidth);

--- a/mods/sc2kfix.h
+++ b/mods/sc2kfix.h
@@ -71,6 +71,12 @@ typedef struct {
 	sc2kfix_mod_hook_t* pstHooks;		// Mandatory
 } sc2kfix_mod_info_t;
 
+typedef struct {
+	HWND hParent;
+	HWND hControl;
+	HWND hToolTip;
+} tooltip_store_t;
+
 #define CTRL(c) (c - 64)
 
 #define COMMAND_TYPE_UNKNOWN		0	// undefined
@@ -103,7 +109,8 @@ HOOKEXT bool bConsoleKeepCommandBuffer;
 HOOKEXT_CPP console::CommandTree treeConsoleCommands;
 
 HOOKEXT void CenterDialogBox(HWND hwndDlg);
-HOOKEXT HWND CreateTooltip(HWND hDlg, HWND hControl, const char* szText);
+HOOKEXT void StoreTooltip(std::vector<tooltip_store_t> &tt_s, HWND hParent, HWND hControl, const char *szText);
+HOOKEXT void DestroyStoredTooltips(std::vector<tooltip_store_t> &tt_s, HWND hParent);
 HOOKEXT const char* HexPls(UINT uNumber, int width);
 HOOKEXT const char* FormatVersion(int iMajor, int iMinor, int iPatch);
 HOOKEXT void ConsoleLog(int iLogLevel, const char* fmt, ...);

--- a/modules/registry_config.cpp
+++ b/modules/registry_config.cpp
@@ -218,6 +218,7 @@ static BOOL InstallSC2KDefaults(void) {
 		SaveJSONSettings();
 		return TRUE;
 	}
+	return FALSE;
 }
 
 int DoCheckAndInstall(void) {

--- a/modules/settings.cpp
+++ b/modules/settings.cpp
@@ -335,75 +335,77 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 		ComboBox_AddString(GetDlgItem(hwndDlg, IDC_SETTINGS_COMBO_MUSICOUTPUT), "MP3 Playback");	// MUSIC_ENGINE_MP3
 		ComboBox_SetMinVisible(GetDlgItem(hwndDlg, IDC_SETTINGS_COMBO_MUSICOUTPUT), 4);
 
+		DestroyStoredTooltips(storedToolTips, hwndDlg);
+
 		// Create tooltips.
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, ID_SETTINGS_OK),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, ID_SETTINGS_OK),
 			"Saves the currently selected settings and closes the settings dialog.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, ID_SETTINGS_CANCEL),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, ID_SETTINGS_CANCEL),
 			"Discards changed settings and closes the settings dialog.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, ID_SETTINGS_DEFAULTS),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, ID_SETTINGS_DEFAULTS),
 			"Changes the settings to the default sc2kfix experience but does not save settings or close the dialog.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, ID_SETTINGS_VANILLA),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, ID_SETTINGS_VANILLA),
 			"Changes the settings to disable all quality of life, interface and gameplay enhancements but does not save settings or close the dialog.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_BUTTON_RESETFILEASSOCIATIONS),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_BUTTON_RESETFILEASSOCIATIONS),
 			"Resets the file association entries in the registry so that .sc2 and .scn files will automatically open in SimCity 2000.");
 
 		// QoL/Performance settings
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_COMBO_MUSICOUTPUT),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_COMBO_MUSICOUTPUT),
 			"Selects the music output driver. Uses Windows MIDI as a fallback option.\n\n"
 			""
 			"None: Disables music playback independent of the per-game music option.\n"
 			"Windows MIDI: Uses the native Windows MIDI sequencer.\n"
 			"FluidSynth: Uses the FluidSynth software synth, if available (default).\n"
 			"MP3 Playback: Uses MP3 files for playback, if available.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_FLUIDSYNTH_SOUNDFONT),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_FLUIDSYNTH_SOUNDFONT),
 			"FluidSynth requires a soundfont for playback that contains the samples and synthesis data required to play back MIDI files. Any SoundFont 2 standard soundfont\n\n"
 			""
 			"Selecting a new soundfont will reset the music engine and restart the currently playing song.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_BUTTON_SOUNDFONTBROWSE),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_BUTTON_SOUNDFONTBROWSE),
 			"Opens a file browser to select a soundfont for FluidSynth. Not needed for Windows MIDI or MP3 playback drivers.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_BKGDMUSIC),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_BKGDMUSIC),
 			"By default, SimCity 2000 stops the currently-playing song when the game window loses focus. This setting continues playing music in the background until the end of the track, "
 			"after which a new song will be selected when the game window regains focus.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SOUND_REPLACEMENTS),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SOUND_REPLACEMENTS),
 			"Certain versions of SimCity 2000 had higher quality sounds than the Windows 95 versions. "
 			"This setting controls whether or not SimCity 2000 plays higher quality versions of various sounds for which said higher quality versions exist.\n\n"
 
 			"Enabling or disabling this setting takes effect after restarting the game.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SHUFFLE_MUSIC),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SHUFFLE_MUSIC),
 			"By default, SimCity 2000 selects \"random\" music by playing the next track in a looping playlist of songs. "
 			"This setting controls whether or not to shuffle the playlist when the game starts and when the end of the playlist is reached.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_REFRESH_RATE),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_REFRESH_RATE),
 			"SimCity 2000 was designed to spend more CPU time on simulation than on rendering by only updating the city's growth when the display moves or on the 24th day of the month. "
 			"Enabling this setting allows the game to refresh the city display in real-time instead of batching display updates.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_ALWAYSPLAYMUSIC),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_ALWAYSPLAYMUSIC),
 			"Enabling this setting will result in the next random music selection being played after the current song finishes.");
 
 		// sc2kfix core settings
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_CONSOLE),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_CONSOLE),
 			"sc2kfix has a debugging console that can be activated by passing the -console argument to SimCity 2000's command line. "
 			"This setting forces sc2kfix to always start the console along with the game, even if the -console argument is not passed.\n\n"
 
 			"Enabling or disabling this setting takes effect after restarting the game.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_CHECK_FOR_UPDATES),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_CHECK_FOR_UPDATES),
 			"This setting checks to see if there's a newer release of sc2kfix available when the game starts.\n\n"
 
 			"Enabling or disabling this setting takes effect after restarting the game.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_DONT_LOAD_MODS),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_DONT_LOAD_MODS),
 			"Enabling this setting forces sc2kfix to skip loading any installed mods on startup.\n\n"
 
 			"Enabling or disabling this setting takes effect after restarting the game.");
 
 		// Interface settings
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_STATUS_DIALOG),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_STATUS_DIALOG),
 			"The DOS and Mac versions of SimCity 2000 used a movable floating dialog to show the current tool, status line, and weather instead of a fixed bar at the bottom of the game window. "
 			"Enabling this setting will use the floating status dialog instead of the bottom status bar.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE),
 			"By default the title bar only displays the month and year. Enabling this setting will display the full in-game date instead.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS),
 			"Certain strings in the game have typos, grammatical issues, and/or ambiguous wording. This setting loads corrected strings in memory in place of the affected originals.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO),
 			"Once enabled the introduction videos will be skipped on startup (This will only apply if the videos have been detected, otherwise the standard warning will be displayed).");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_DARK_UNDGRND),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_DARK_UNDGRND),
 			"When enabled the underground layer background will be dark.");
 
 		// Set the version string.
@@ -550,6 +552,11 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 			return DoConfigureKeyBindings(st, hwndDlg);
 		}
 		return TRUE;
+
+	case WM_DESTROY:
+		DestroyStoredTooltips(storedToolTips, hwndDlg);
+
+		break;
 	}
 	return FALSE;
 }

--- a/modules/settings_dialog.cpp
+++ b/modules/settings_dialog.cpp
@@ -71,23 +71,25 @@ static BOOL CALLBACK SettingsDialogGeneralTabProc(HWND hwndDlg, UINT message, WP
 		SendMessage(GetDlgItem(hwndDlg, IDC_STATIC_RELEASEBANNER), WM_SETFONT, (WPARAM)hSystemRegular12, TRUE);
 		InvalidateRect(hwndDlg, NULL, TRUE);
 
+		DestroyStoredTooltips(storedToolTips, hwndDlg);
+
 		// Create tooltips
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_BUTTON_RESETFILEASSOCIATIONS),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_BUTTON_RESETFILEASSOCIATIONS),
 			"Resets the file association entries in the registry so that .sc2 and .scn files will automatically open in SimCity 2000.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_CONSOLE),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_CONSOLE),
 			"sc2kfix has a debugging console that can be activated by passing the -console argument to SimCity 2000's command line. "
 			"This setting forces sc2kfix to always start the console along with the game, even if the -console argument is not passed.\n\n"
 
 			"Enabling or disabling this setting takes effect after restarting the game.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_CHECK_FOR_UPDATES),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_CHECK_FOR_UPDATES),
 			"This setting checks to see if there's a newer release of sc2kfix available when the game starts.\n\n"
 
 			"Enabling or disabling this setting takes effect after restarting the game.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_DONT_LOAD_MODS),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_DONT_LOAD_MODS),
 			"Enabling this setting forces sc2kfix to skip loading any installed mods on startup.\n\n"
 
 			"Enabling or disabling this setting takes effect after restarting the game.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO),
 			"Once enabled the introduction videos will be skipped on startup. Only applies if videos have been detected.\n\n"
 
 			"Enabling or disabling this setting takes effect after restarting the game.");
@@ -113,6 +115,8 @@ static BOOL CALLBACK SettingsDialogGeneralTabProc(HWND hwndDlg, UINT message, WP
 		GET_CHECKBOX(jsonSettingsCoreWorkingCopy[C_SC2KFIX][S_FIX_CORE][I_FIX_CORE_CHECKFORUPD], IDC_SETTINGS_CHECK_CHECK_FOR_UPDATES);
 		GET_CHECKBOX(jsonSettingsCoreWorkingCopy[C_SC2KFIX][S_FIX_CORE][I_FIX_CORE_SKIPMODS], IDC_SETTINGS_CHECK_DONT_LOAD_MODS);
 		GET_CHECKBOX(jsonSettingsCoreWorkingCopy[C_SC2KFIX][S_FIX_QOL][I_FIX_QOL_SKIPINTRO], IDC_SETTINGS_CHECK_SKIP_INTRO);
+
+		DestroyStoredTooltips(storedToolTips, hwndDlg);
 
 		return TRUE;
 
@@ -142,21 +146,23 @@ static BOOL CALLBACK SettingsDialogGameplayTabProc(HWND hwndDlg, UINT message, W
 			(stSettingsDialogHeader.rcDisplay.bottom - stSettingsDialogHeader.rcDisplay.top),
 			SWP_SHOWWINDOW);
 
+		DestroyStoredTooltips(storedToolTips, hwndDlg);
+
 		// Create tooltips
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_STATUS_DIALOG),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_STATUS_DIALOG),
 			"The DOS and Mac versions of SimCity 2000 used a movable floating dialog to show the current tool, status line, and weather instead of a fixed bar at the bottom of the game window. "
 			"Enabling this setting will use the floating status dialog instead of the bottom status bar.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE),
 			"By default the title bar only displays the month and year. Enabling this setting will display the full in-game date instead.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS),
 			"Certain strings in the game have typos, grammatical issues, and/or ambiguous wording. This setting loads corrected strings in memory in place of the affected originals.");
 
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_REFRESH_RATE),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_REFRESH_RATE),
 			"SimCity 2000 was designed to spend more CPU time on simulation than on rendering by only updating the city's growth when the display moves or on the 24th day of the month. "
 			"Enabling this setting allows the game to refresh the city display in real-time instead of batching display updates.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_DARK_UNDGRND),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_DARK_UNDGRND),
 			"When enabled the underground layer background will be dark.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SOUND_REPLACEMENTS),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SOUND_REPLACEMENTS),
 			"Certain versions of SimCity 2000 had higher quality sounds than the Windows 95 versions. "
 			"This setting controls whether or not SimCity 2000 plays higher quality versions of various sounds for which said higher quality versions exist.\n\n"
 
@@ -182,6 +188,8 @@ static BOOL CALLBACK SettingsDialogGameplayTabProc(HWND hwndDlg, UINT message, W
 		GET_CHECKBOX(jsonSettingsCoreWorkingCopy[C_SC2KFIX][S_FIX_QOL][I_FIX_QOL_FREQUPDATES], IDC_SETTINGS_CHECK_REFRESH_RATE);
 		GET_CHECKBOX(jsonSettingsCoreWorkingCopy[C_SC2KFIX][S_FIX_QOL][I_FIX_QOL_DARKUNDGRND], IDC_SETTINGS_CHECK_DARK_UNDGRND);
 		GET_CHECKBOX(jsonSettingsCoreWorkingCopy[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_USESNDREPLACE], IDC_SETTINGS_CHECK_SOUND_REPLACEMENTS);
+
+		DestroyStoredTooltips(storedToolTips, hwndDlg);
 
 		return TRUE;
 
@@ -224,28 +232,30 @@ static BOOL CALLBACK SettingsDialogAudioTabProc(HWND hwndDlg, UINT message, WPAR
 		ComboBox_AddString(GetDlgItem(hwndDlg, IDC_SETTINGS_COMBO_MUSICOUTPUT), "MP3 Playback");	// MUSIC_ENGINE_MP3
 		ComboBox_SetMinVisible(GetDlgItem(hwndDlg, IDC_SETTINGS_COMBO_MUSICOUTPUT), 4);
 
+		DestroyStoredTooltips(storedToolTips, hwndDlg);
+
 		// Create tooltips
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_COMBO_MUSICOUTPUT),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_COMBO_MUSICOUTPUT),
 			"Selects the music output driver. Uses Windows MIDI as a fallback option.\n\n"
 			""
 			"None: Disables music playback independent of the per-game music option.\n"
 			"Windows MIDI: Uses the native Windows MIDI sequencer.\n"
 			"FluidSynth: Uses the FluidSynth software synth, if available (default).\n"
 			"MP3 Playback: Uses MP3 files for playback, if available.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_FLUIDSYNTH_SOUNDFONT),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_FLUIDSYNTH_SOUNDFONT),
 			"FluidSynth requires a soundfont for playback that contains the samples and synthesis data required to play back MIDI files. Any SoundFont 2 standard soundfont can be selected. "
 			"By default, sc2kfix uses the General MIDI soundfont included with Windows that the MIDI sequencer uses.\n\n"
 			""
 			"Selecting a new soundfont will reset the music engine and restart the currently playing song.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_BUTTON_SOUNDFONTBROWSE),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_BUTTON_SOUNDFONTBROWSE),
 			"Opens a file browser to select a soundfont for FluidSynth. Not needed for Windows MIDI or MP3 playback drivers.");
 
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_BKGDMUSIC),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_BKGDMUSIC),
 			"By default, SimCity 2000 stops the currently-playing song when the game window loses focus. This setting continues playing music in the background until the end of the track, "
 			"after which a new song will be selected when the game window regains focus.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_ALWAYSPLAYMUSIC),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_ALWAYSPLAYMUSIC),
 			"Enabling this setting will result in the next random music selection being played after the current song finishes.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SHUFFLE_MUSIC),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SHUFFLE_MUSIC),
 			"By default, SimCity 2000 selects \"random\" music by playing the next track in a looping playlist of songs. "
 			"This setting controls whether or not to shuffle the playlist when the game starts and when the end of the playlist is reached.");
 
@@ -281,6 +291,8 @@ static BOOL CALLBACK SettingsDialogAudioTabProc(HWND hwndDlg, UINT message, WPAR
 		GET_CHECKBOX(jsonSettingsCoreWorkingCopy[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICINBKGRND], IDC_SETTINGS_CHECK_BKGDMUSIC);
 		GET_CHECKBOX(jsonSettingsCoreWorkingCopy[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SHUFFLEMUSIC], IDC_SETTINGS_CHECK_SHUFFLE_MUSIC);
 		GET_CHECKBOX(jsonSettingsCoreWorkingCopy[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_ALWAYSPLAYMUSIC], IDC_SETTINGS_CHECK_ALWAYSPLAYMUSIC);
+
+		DestroyStoredTooltips(storedToolTips, hwndDlg);
 
 		return TRUE;
 
@@ -319,6 +331,8 @@ static BOOL CALLBACK TabDlg(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lP
 			(stSettingsDialogHeader.rcDisplay.bottom - stSettingsDialogHeader.rcDisplay.top),
 			SWP_SHOWWINDOW);
 
+		DestroyStoredTooltips(storedToolTips, hwndDlg);
+
 		// Create tooltips
 		
 		// Set fields based on the working JSON
@@ -327,6 +341,8 @@ static BOOL CALLBACK TabDlg(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lP
 
 	case WM_DESTROY:
 		// Update the working JSON based on our fields
+
+		DestroyStoredTooltips(storedToolTips, hwndDlg);
 
 		return TRUE;
 
@@ -350,14 +366,16 @@ BOOL CALLBACK SettingsDialogContainerProc(HWND hwndDlg, UINT message, WPARAM wPa
 		SendMessage(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)LoadIcon(hSC2KFixModule, MAKEINTRESOURCE(IDI_TOPSECRET)));
 		SendMessage(hwndDlg, WM_SETICON, ICON_SMALL, (LPARAM)LoadIcon(hSC2KFixModule, MAKEINTRESOURCE(IDI_TOPSECRET)));
 
+		DestroyStoredTooltips(storedToolTips, hwndDlg);
+
 		// Create tooltips
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDOK),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDOK),
 			"Saves the currently selected settings and closes the settings dialog.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDCANCEL),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDCANCEL),
 			"Discards changed settings and closes the settings dialog.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_BUTTON_DEFAULTS),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_BUTTON_DEFAULTS),
 			"Changes the settings to the default sc2kfix experience but does not save settings or close the dialog.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_BUTTON_VANILLA),
+		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_BUTTON_VANILLA),
 			"Changes the settings to disable all quality of life, interface and gameplay enhancements but does not save settings or close the dialog.");
 
 		// Set the version string.
@@ -485,6 +503,11 @@ BOOL CALLBACK SettingsDialogContainerProc(HWND hwndDlg, UINT message, WPARAM wPa
 			SettingsTabSelectionChanged(hwndDlg);
 			break;
 		}
+		return TRUE;
+
+	case WM_DESTROY:
+		DestroyStoredTooltips(storedToolTips, hwndDlg);
+
 		return TRUE;
 
 	// Handle the tab selection

--- a/utility.cpp
+++ b/utility.cpp
@@ -56,16 +56,12 @@ HOOKEXT void CenterDialogBox(HWND hwndDlg) {
 
 // Creates a Win32 common controls tooltip and assigns it to a given control in a given window.
 // XXX - Technically leaks a small amount of memory, as _strdup() is called on each invocation.
-HOOKEXT HWND CreateTooltip(HWND hDlg, HWND hControl, const char* szText) {
+static HWND CreateTooltip(HWND hDlg, HWND hControl, const char* szText) {
 	if (!hDlg || !hControl || !szText)
 		return NULL;
 
 	HWND hTooltip = CreateWindowEx(WS_EX_TOPMOST, TOOLTIPS_CLASS, NULL, WS_POPUP | TTS_ALWAYSTIP | TTS_NOPREFIX, 0, 0, 0, 0, hDlg, NULL, hSC2KFixModule, NULL);
 	if (!hTooltip)
-		return NULL;
-
-	char* lpszText = _strdup(szText);
-	if (!lpszText)
 		return NULL;
 
 	SendMessage(hTooltip, TTM_ACTIVATE, TRUE, 0);
@@ -74,12 +70,53 @@ HOOKEXT HWND CreateTooltip(HWND hDlg, HWND hControl, const char* szText) {
 	TOOLINFO tooltipInfo = { 0 };
 	tooltipInfo.cbSize = sizeof(TOOLINFO);
 	tooltipInfo.hwnd = hDlg;
-	tooltipInfo.uId = (UINT_PTR)hControl;
 	tooltipInfo.uFlags = TTF_SUBCLASS | TTF_IDISHWND;
-	tooltipInfo.lpszText = lpszText;
+	tooltipInfo.uId = (UINT_PTR)hControl;
+	tooltipInfo.lpszText = (LPSTR) szText;
 	SendMessage(hTooltip, TTM_ADDTOOL, NULL, (LPARAM)&tooltipInfo);
 
 	return hTooltip;
+}
+
+// Create and store tooltip for later destruction.
+HOOKEXT void StoreTooltip(std::vector<tooltip_store_t> &tt_s, HWND hParent, HWND hControl, const char *szText) {
+	HWND hToolTip;
+	tooltip_store_t tt_item;
+
+	hToolTip = CreateTooltip(hParent, hControl, szText);
+	if (hToolTip) {
+		tt_item.hParent = hParent;
+		tt_item.hControl = hControl;
+		tt_item.hToolTip = hToolTip;
+		tt_s.push_back(tt_item);
+	}
+}
+
+// Destroys the stored tooltip and frees the string.
+static void DeleteTooltip(HWND hDlg, HWND hControl, HWND hTooltip) {
+	if (!hDlg || !hControl || !hTooltip)
+		return;
+
+	TOOLINFO tooltipInfo = { 0 };
+	tooltipInfo.cbSize = sizeof(TOOLINFO);
+	tooltipInfo.hwnd = hDlg;
+	tooltipInfo.uFlags = TTF_IDISHWND;
+	tooltipInfo.uId = (UINT_PTR)hControl;
+	SendMessage(hTooltip, TTM_DELTOOL, 0, (LPARAM)&tooltipInfo);
+
+	DestroyWindow(hTooltip);
+}
+
+// Destroy associated tooltip entries.
+HOOKEXT void DestroyStoredTooltips(std::vector<tooltip_store_t> &tt_s, HWND hParent) {
+	for (std::vector<tooltip_store_t>::iterator it = tt_s.begin(); it != tt_s.end();) {
+		if (it->hParent == hParent) {
+			DeleteTooltip(it->hParent, it->hControl, it->hToolTip);
+			it = tt_s.erase(it);
+		}
+		else
+			++it;
+	}
 }
 
 // Formats a hexadecimal number in a very temporary C string.


### PR DESCRIPTION
Tooltip handles (with the parent and attached control) are now stored in a vector.

Upon WM_DESTROY associated tooltips are cleaned up.