### PR TITLE
Scenario Dialogue - PICT palette remap fix

### DIFF
--- a/hooks/hook_sc2k1995_miscellaneous.cpp
+++ b/hooks/hook_sc2k1995_miscellaneous.cpp
@@ -352,6 +352,12 @@ void InstallMiscHooks_SC2K1995(void) {
 	SafeVirtualProtect((LPVOID)0x42E737, 5, PAGE_EXECUTE_READWRITE);
 	NEWJMP((LPVOID)0x42E737, Hook_1995_LoadCityCancelFix);
 
+	// Fix the black <-> white palette index swap
+	// that occurs within CGraphics::RemapBitmapColors(BOOL)
+	// eax rather than ecx.
+	SafeVirtualProtect((LPVOID)0x47643F, 1, PAGE_EXECUTE_READWRITE);
+	*(BYTE*)0x47643F = 0x84; // This was 0x8C
+
 	// Fix the 'Arial" font
 	SafeVirtualProtect((LPVOID)0x4E6234, 6, PAGE_EXECUTE_READWRITE);
 	memset((LPVOID)0x4E6234, 0, 6);

--- a/hooks/hook_sc2k1996_miscellaneous.cpp
+++ b/hooks/hook_sc2k1996_miscellaneous.cpp
@@ -2272,6 +2272,12 @@ void InstallMiscHooks_SC2K1996(void) {
 	SafeVirtualProtect((LPVOID)0x401532, 5, PAGE_EXECUTE_READWRITE);
 	NEWJMP((LPVOID)0x401532, Hook_GameDialog_OnDestroy);
 
+	// Fix the black <-> white palette index swap
+	// that occurs within CGraphics::RemapBitmapColors(BOOL)
+	// eax rather than ecx.
+	SafeVirtualProtect((LPVOID)0x475F5F, 1, PAGE_EXECUTE_READWRITE);
+	*(BYTE*)0x475F5F = 0x84; // This was 0x8C
+
 	// Fix the sign fonts
 	SafeVirtualProtect((LPVOID)0x4E7267, 1, PAGE_EXECUTE_READWRITE);
 	*(BYTE*)0x4E7267 = 'a';


### PR DESCRIPTION
Palette index 1 within the PaletteBitmapRemap(BOOL) call was originally being set to the old value set at index position 0 (rather than after 0 had been set to 255).

This resulted in white patches in certain PICT images (such as Charleston).

This has now been corrected.

This applies to both the 1996 Special Edition and 1995 CD Collection versions.