### PR TITLE
SDL Sound/Song Threads

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -434,6 +434,10 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 		CreateThread(NULL, 0, MusicThread, 0, 0, &dwMusicThreadID);
 		ConsoleLog(LOG_INFO, "MUS:  Music thread started.\n");
 
+		CreateThread(NULL, 0, SDLSoundThread, 0, 0, &dwSDLSoundThreadID);
+		CreateThread(NULL, 0, SDLSongThread, 0, 0, &dwSDLSongThreadID);
+		ConsoleLog(LOG_INFO, "SND:  SDL Sound threads started.\n");
+
 		// Palette animation fix
 		BOOL bCanFixAnimation;
 
@@ -561,6 +565,11 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 
 	// Clean up after ourselves and get ready to exit
 	case DLL_PROCESS_DETACH:
+		if (dwSDLSongThreadID)
+			PostThreadMessage(dwSDLSongThreadID, WM_QUIT, NULL, NULL);
+		if (dwSDLSoundThreadID)
+			PostThreadMessage(dwSDLSoundThreadID, WM_QUIT, NULL, NULL);
+
 		// Shut down the music thread
 		if (dwMusicThreadID)
 			PostThreadMessage(dwMusicThreadID, WM_QUIT, NULL, NULL);

--- a/hooks/hook_sc2k1996_miscellaneous.cpp
+++ b/hooks/hook_sc2k1996_miscellaneous.cpp
@@ -1940,8 +1940,7 @@ extern "C" void __stdcall Hook_MainFrame_OnActivateApp(BOOL bActive, HTASK hTask
 				// music in background is not enabled.
 				if (!jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICINBKGRND].ToBool())
 					Game_SimcityApp_MusicTrigger(pSCApp);
-				SoundEngineStopStream(&pStreamCurrentSound);
-				//L_PlaySound_SC2K1996(0, 0); // Review concerning sound call change.
+				L_PlaySound_SC2K1996(0, 0);
 				InvalidateRect(pThis->m_hWnd, 0, TRUE);
 				if (pSCView)
 					Game_SimcityView_MainWindowUpdate(pSCView, 0, FALSE);
@@ -1957,6 +1956,9 @@ extern "C" void __stdcall Hook_MainFrame_OnActivateApp(BOOL bActive, HTASK hTask
 				if (pSCView) {
 					if (!Game_Sound_GetMCIResult(pSCApp->SCASNDLayer))
 						Game_SimcityApp_MusicPlayNextRefocusSong(pSCApp);
+					// Added to get things going again.
+					bSoundKickstart = true;
+					Game_SimcityApp_SoundPlaySound(pSCApp, SOUND_SILENT);
 				}
 			}
 			Game_SimcityApp_SetGameCursor(pSCApp, 0, TRUE);
@@ -1978,8 +1980,7 @@ extern "C" void __stdcall Hook_MainFrame_OnSize(UINT nType, int cx, int cy) {
 		if (!jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICINBKGRND].ToBool())
 			Game_SimcityApp_MusicTrigger(pSCApp);
 
-		SoundEngineStopStream(&pStreamCurrentSound);
-		//L_PlaySound_SC2K1996(0, 0); // Review concerning sound call change.
+		L_PlaySound_SC2K1996(0, 0);
 	}
 	Game_MainFrame_OnQueryNewPalette(pThis);
 	InvalidateRect(pThis->m_hWnd, 0, TRUE);
@@ -2005,14 +2006,16 @@ extern "C" void __stdcall Hook_MainFrame_OnShowWindow(BOOL bShow, BOOL nStatus) 
 		if (pSCView) {
 			if (!Game_Sound_GetMCIResult(pSCApp->SCASNDLayer))
 				Game_SimcityApp_MusicPlayNextRefocusSong(pSCApp);
+			// Added to get things going again.
+			bSoundKickstart = true;
+			Game_SimcityApp_SoundPlaySound(pSCApp, SOUND_SILENT);
 		}
 	}
 	else {
 		if (!jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICINBKGRND].ToBool())
 			Game_SimcityApp_MusicTrigger(pSCApp);
 
-		SoundEngineStopStream(&pStreamCurrentSound);
-		//L_PlaySound_SC2K1996(0, 0); // Review concerning sound call change.
+		L_PlaySound_SC2K1996(0, 0);
 	}
 	Game_SimcityDoc_UpdateDocumentTitle(pCSimcityDoc);
 }
@@ -2393,6 +2396,17 @@ extern "C" int __stdcall Hook_SimcityApp_InitInstance() {
 	return GameMain_SimcityApp_InitInstance(pThis);
 }
 
+extern "C" void __stdcall Hook_SimcityApp_ExitInstance() {
+	CSimcityAppPrimary* pThis;
+
+	__asm mov [pThis], ecx
+
+	Game_PerhapsFreeDocumentsLibraryAndStrings();
+	FreeLibrary(pThis->dwSCAhModule);
+	SoundEngineDestroy();
+	GameMain_WinApp_ExitInstance(pThis);
+}
+
 // Install hooks and run code that we only want to do for the 1996 Special Edition SIMCITY.EXE.
 // This should probably have a better name. And maybe be broken out into smaller functions.
 //
@@ -2401,6 +2415,10 @@ void InstallMiscHooks_SC2K1996(void) {
 	// Install early startup hook before CSimcityApp::InitInstance
 	SafeVirtualProtect((LPVOID)0x4016B3, 5, PAGE_EXECUTE_READWRITE);
 	NEWJMP((LPVOID)0x4016B3, Hook_SimcityApp_InitInstance);
+
+	// Hook CSimcityApp::ExitInstance
+	SafeVirtualProtect((LPVOID)0x402E5F, 5, PAGE_EXECUTE_READWRITE);
+	NEWJMP((LPVOID)0x402E5F, Hook_SimcityApp_ExitInstance);
 	
 	// Install critical Windows API hooks
 	*(DWORD*)(0x4EFBE8) = (DWORD)Hook_LoadStringA;

--- a/hooks/hook_sndPlaySound.cpp
+++ b/hooks/hook_sndPlaySound.cpp
@@ -32,13 +32,17 @@ std::map<DWORD, soundbufferinfo_t> mapSoundBuffers;
 std::map<int, sound_replacement_t> mapReplacementSounds;
 std::map<int, audio_entity_t> mapSoundCache;
 
+bool bSoundKickstart = false;
+
 static DWORD dwDummy;
+
+static bool LoadSoundFromFile(int iSoundID, std::string strPath);
 
 static int GetSoundPosBySoundID(int iSoundID) {
 	return iSoundID - SOUND_START;
 }
 
-static int GetSoundPlayTicksBySoundID_SC2K1996(int iSoundID) {
+int GetSoundPlayTicksBySoundID_SC2K1996(int iSoundID) {
 	for (int i = 0; i < SOUND_ENTRIES; i++) {
 		if (GetSoundPosBySoundID(iSoundID) == i) {
 			if (snd_debug & SND_DEBUG_INTERNALS)
@@ -49,7 +53,7 @@ static int GetSoundPlayTicksBySoundID_SC2K1996(int iSoundID) {
 	return 0;
 }
 
-static int GetTickDurationBySoundID_SC2K1996(int iSoundID, int nDuration) {
+int GetTickDurationBySoundID_SC2K1996(int iSoundID, int nDuration) {
 	// For clarity it interpreted the needed array position based off
 	// of the following originally for the address:
 	// *((DWORD *)&rgbLoColor[8].wPos + iSoundID)
@@ -150,17 +154,17 @@ extern "C" void __stdcall Hook_Sound_InitSoundLayer(HWND m_hWnd) {
 	GameMain_String_Dest(&strSndPath);
 }
 
-BOOL L_PlaySound_SC2K1996(LPCTSTR pszSound, UINT fuSound) {
-	if (snd_debug & SND_DEBUG_PLAYS) {
-		if (fuSound & SND_MEMORY)
-			ConsoleLog(LOG_DEBUG, "SND:  L_PlaySound_SC2K1996(<0x%06X>, 0x%06X)\n", pszSound, fuSound);
-		else if (!pszSound && !fuSound)
-			ConsoleLog(LOG_DEBUG, "SND:  L_PlaySound_SC2K1996(0, 0)\n");
-		else
-			ConsoleLog(LOG_DEBUG, "SND:  L_PlaySound_SC2K1996(%s, 0x%06X)\n", (pszSound ? pszSound : "NULL"), fuSound);
+void L_PlaySound_SC2K1996(int nAttrib, int nDuration) {
+	if (nAttrib) {
+		if (snd_debug & SND_DEBUG_PLAYS)
+			ConsoleLog(LOG_DEBUG, "SND:  L_PlaySound_SC2K1996(%d, %d) - Play: (%d, %d)\n", nAttrib, nDuration, LOWORD(nAttrib), HIWORD(nAttrib));
+		PostThreadMessageA(dwSDLSoundThreadID, WM_SDL_PLAY, (WPARAM)nDuration, (LPARAM)nAttrib);
 	}
-	return sndPlaySoundA(pszSound, fuSound);
-	//return PlaySoundA(pszSound, NULL, fuSound);
+	else {
+		if (snd_debug & SND_DEBUG_PLAYS)
+			ConsoleLog(LOG_DEBUG, "SND:  L_PlaySound_SC2K1996(0, 0) - Stop\n");
+		PostThreadMessageA(dwSDLSoundThreadID, WM_SDL_STOP, 0, 0);
+	}
 }
 
 extern "C" void __stdcall Hook_Sound_StopSoundBySoundID(int iSoundID) {
@@ -177,8 +181,7 @@ extern "C" void __stdcall Hook_Sound_StopSound() {
 
 	__asm mov [pThis], ecx
 
-	SoundEngineStopStream(&pStreamCurrentSound);
-	//L_PlaySound_SC2K1996(0, 0);
+	L_PlaySound_SC2K1996(0, 0);
 	pThis->bSNDWasPlaying = FALSE;
 	Game_Sound_PlayPrioritySound(pThis);
 }
@@ -208,24 +211,28 @@ extern "C" int __stdcall Hook_LoadSoundIntoBuffer(int iSoundID, void* lpBuffer) 
 	}
 	else {
 		char szSoundFileName[24 + 1], szCurrentSoundPath[MAX_PATH + 1];
-		CMFC3XFile cFile;
-		GameMain_File_Cons(&cFile);
 		if (lpBuffer) {
 			strcpy_s(szCurrentSoundPath, sizeof(szCurrentSoundPath) - 1, szSoundPath);
 			sprintf_s(szSoundFileName, sizeof(szSoundFileName) - 1, aDWav, iSoundID);
 			strcat_s(szCurrentSoundPath, sizeof(szCurrentSoundPath) - 1, szSoundFileName);
 			if (snd_debug & SND_DEBUG_INTERNALS)
 				ConsoleLog(LOG_DEBUG, "LoadSoundIntoBuffer(%d, 0x%06X): [%s] [%s]\n", iSoundID, lpBuffer, szCurrentSoundPath, szSoundFileName);
-			if (GameMain_File_Open(&cFile, szCurrentSoundPath, 0, 0)) {
-				nNumBytesToRead = GameMain_File_GetLength(&cFile);
-				GameMain_File_Read(&cFile, lpBuffer, nNumBytesToRead);
-				GameMain_File_Close(&cFile);
+			FILE *f = old_fopen(szCurrentSoundPath, "rb");
+			if (f) {
+				fseek(f, 0, SEEK_END);
+				nNumBytesToRead = ftell(f);
+				fseek(f, 0, SEEK_SET);
+				fread(lpBuffer, nNumBytesToRead, 1, f);
+				fclose(f);
 				bSuccess = TRUE;
 			}
 			if (snd_debug & SND_DEBUG_INTERNALS)
 				ConsoleLog(LOG_DEBUG, "LoadSoundIntoBuffer(%d, 0x%06X): [%s] [%s] - bSuccess(%d)\n", iSoundID, lpBuffer, szCurrentSoundPath, szSoundFileName, bSuccess);
+			// This should only be encountered if the original file failed to load
+			// and was never cached.
+			if (!mapSoundCache[iSoundID].pBuffer)
+				bSuccess = LoadSoundFromFile(iSoundID, string_format("SOUNDS/%d.wav", iSoundID)) ? TRUE : FALSE;
 		}
-		GameMain_File_Dest(&cFile);
 	}
 
 	return bSuccess;
@@ -273,12 +280,23 @@ extern "C" void __stdcall Hook_Sound_DestroySoundLayer() {
 	_heapmin();
 }
 
+static int __stdcall L_Sound_LoadActionThingSound_SC2K1996(CSound *pSound, int iSoundID) {
+	if (pSound->iSNDActionThingSoundID != iSoundID) {
+		if (Game_LoadSoundIntoBuffer(iSoundID, pSound->dwSNDBufferActionThing))
+			pSound->iSNDActionThingSoundID = iSoundID;
+		else
+			pSound->iSNDActionThingSoundID = SOUND_BULLDOZER;
+	}
+	return pSound->iSNDActionThingSoundID;
+}
+
 extern "C" void __stdcall Hook_Sound_PlayActionThingSound(int iSoundID, int nDuration) {
 	CSound *pThis;
 
 	__asm mov [pThis], ecx
 
 	CSimcityAppPrimary *pSCApp;
+	int nAttrib;
 
 	pSCApp = &pCSimcityAppThis;
 	if (pSCApp->dwSCAGameSound) {
@@ -291,41 +309,11 @@ extern "C" void __stdcall Hook_Sound_PlayActionThingSound(int iSoundID, int nDur
 				nCurrentActionThingSoundID = iSoundID;
 			else {
 				if (iSoundID != pThis->iSNDActionThingSoundID)
-					Game_Sound_LoadActionThingSound(pThis, iSoundID);
+					iSoundID = L_Sound_LoadActionThingSound_SC2K1996(pThis, iSoundID);
 				pThis->bSNDWasPlaying = TRUE;
-				if (pThis->iSNDActionThingSoundID == iSoundID && pThis->dwSNDBufferActionThing != 0) {
-					if (SoundEnginePlayStream(&pStreamCurrentSound, &mapSoundCache[iSoundID],
-						jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SOUNDVOLUME].ToFloat() * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MASTERVOLUME].ToFloat(),
-						true, true)) {
-					//if (L_PlaySound_SC2K1996((LPCSTR)pThis->dwSNDBufferActionThing, SND_ASYNC | SND_MEMORY | SND_LOOP)) {
-						pThis->iSNDActionThingSoundID = iSoundID;
-						pThis->iSNDCurrSoundID = iSoundID;
-						pThis->bSNDPlaySound = TRUE;
-						pThis->bSNDWasPlaying = TRUE;
-						nActionThingSoundPlayTicks = (nDuration <= 0) ? 0 : GetTickDurationBySoundID_SC2K1996(iSoundID, nDuration);
-						if (snd_debug & SND_DEBUG_INTERNALS)
-							ConsoleLog(LOG_DEBUG, "CSound::PlayActionThingSound(%d, %d): nActionThingSoundPlayTicks(%d)\n", iSoundID, nDuration, nActionThingSoundPlayTicks);
-					}
-					else
-						pThis->bSNDWasPlaying = FALSE;
-				}
-				else {
-					if (snd_debug & SND_DEBUG_INTERNALS)
-						ConsoleLog(LOG_DEBUG, "CSound::PlayActionThingSound(%d, %d): ActionSoundBufferEmpty.\n");
-
-					/*char szSoundFileName[24 + 1], szCurrentSoundPath[MAX_PATH + 1];
-
-					strcpy_s(szCurrentSoundPath, sizeof(szCurrentSoundPath) - 1, szSoundPath);
-					sprintf_s(szSoundFileName, sizeof(szSoundFileName) - 1, aDWav, iSoundID);
-					strcat_s(szCurrentSoundPath, sizeof(szCurrentSoundPath) - 1, szSoundFileName);
-					pThis->bSNDPlaySound = L_PlaySound_SC2K1996(szCurrentSoundPath, SND_ASYNC | SND_NODEFAULT | SND_LOOP);*/
-					pThis->bSNDPlaySound = SoundEnginePlayStream(&pStreamCurrentSound, &mapSoundCache[iSoundID],
-						jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SOUNDVOLUME].ToFloat() * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MASTERVOLUME].ToFloat(),
-						true, true);
-					nActionThingSoundPlayTicks = (nDuration <= 0) ? 0 : GetTickDurationBySoundID_SC2K1996(iSoundID, nDuration);
-					pThis->iSNDCurrSoundID = iSoundID;
-					pThis->bSNDWasPlaying = pThis->bSNDPlaySound;
-				}
+				ULOWORD(nAttrib) = iSoundID;
+				UHIWORD(nAttrib) = (pThis->iSNDActionThingSoundID == iSoundID && pThis->dwSNDBufferActionThing != 0) ? SND_ORIG_ACTSND_EXIST : SND_ORIG_ACTSND_NONBUF;
+				L_PlaySound_SC2K1996(nAttrib, nDuration);
 			}
 		}
 	}
@@ -421,10 +409,7 @@ extern "C" void __stdcall Hook_Sound_LoadActionThingSound(int iSoundID) {
 
 	__asm mov [pThis], ecx
 
-	if (pThis->iSNDActionThingSoundID != iSoundID) {
-		if (Game_LoadSoundIntoBuffer(iSoundID, pThis->dwSNDBufferActionThing))
-			pThis->iSNDActionThingSoundID = iSoundID;
-	}
+	L_Sound_LoadActionThingSound_SC2K1996(pThis, iSoundID);
 }
 
 extern "C" void __stdcall Hook_Sound_StopActionThingSound(int iSoundID) {
@@ -435,8 +420,7 @@ extern "C" void __stdcall Hook_Sound_StopActionThingSound(int iSoundID) {
 	if (pThis->iSNDActionThingSoundID == iSoundID) {
 		pThis->bSNDWasPlaying = FALSE;
 		if (pThis->iSNDCurrSoundID == iSoundID) {
-			SoundEngineStopStream(&pStreamCurrentSound);
-			//L_PlaySound_SC2K1996(0, 0);
+			L_PlaySound_SC2K1996(0, 0);
 			pThis->bSNDPlaySound = FALSE;
 			pThis->iSNDCurrSoundID = -1;
 		}
@@ -449,6 +433,7 @@ extern "C" void __stdcall Hook_Sound_PlaySound(int iSoundID) {
 	__asm mov [pThis], ecx
 
 	CSimcityAppPrimary *pSCApp;
+	int nAttrib;
 
 	pSCApp = &pCSimcityAppThis;
 	if (pSCApp->dwSCAGameSound) {
@@ -457,48 +442,22 @@ extern "C" void __stdcall Hook_Sound_PlaySound(int iSoundID) {
 				return;
 		}
 		if (iSoundID >= SOUND_START && 
-			iSoundID < SOUND_SILENT) {
+			iSoundID < SOUND_SILENT || bSoundKickstart) {
+			if (bSoundKickstart) {
+				bSoundKickstart = false;
+				if (iSoundID < SOUND_START || iSoundID > SOUND_SILENT)
+					return;
+			}
 			int nSoundPlayTicksEntry = GetSoundPlayTicksBySoundID_SC2K1996(iSoundID);
 			if (!pThis->bSNDPlaySound || pThis->iSNDCurrSoundID != iSoundID || nSoundPlayTicksEntry - nActionThingSoundPlayTicks >= 3) {
+				ULOWORD(nAttrib) = iSoundID;
+				UHIWORD(nAttrib) = SND_ORIG_PLAYSND;
 				if (pThis->iSNDActionThingSoundID == pThis->iSNDCurrSoundID && pThis->bSNDWasPlaying)
 					nActionThingSoundPlayTicksCurrent = nActionThingSoundPlayTicks;
 				else
 					nActionThingSoundPlayTicksCurrent = 0;
 
-				/*BOOL bRet = -1;
-				if (iSoundID == SOUND_CLICK && pThis->dwSNDBufferClick != 0)
-					bRet = L_PlaySound_SC2K1996((LPCSTR)pThis->dwSNDBufferClick, SND_ASYNC | SND_NODEFAULT | SND_MEMORY);
-				else if (iSoundID == SOUND_EXPLODE && pThis->dwSNDBufferExplosion != 0)
-					bRet = L_PlaySound_SC2K1996((LPCSTR)pThis->dwSNDBufferExplosion, SND_ASYNC | SND_NODEFAULT | SND_MEMORY);
-				else if (pThis->iSNDToolSoundID == iSoundID && pThis->dwSNDBufferTool != 0)
-					bRet = L_PlaySound_SC2K1996((LPCSTR)pThis->dwSNDBufferTool, SND_ASYNC | SND_NODEFAULT | SND_MEMORY);
-				else {
-					if (pThis->iSNDActionThingSoundID == iSoundID) {
-						if (pThis->dwSNDBufferActionThing) {
-							bRet = L_PlaySound_SC2K1996((LPCSTR)pThis->dwSNDBufferActionThing, SND_ASYNC | SND_NODEFAULT | SND_MEMORY | SND_LOOP);
-							pThis->bSNDWasPlaying = bRet;
-						}
-					}
-					if (bRet < 0) {
-						if (pThis->iSNDGeneralSoundID != iSoundID) {
-							Game_LoadSoundIntoBuffer(iSoundID, pThis->dwSNDBufferGeneral);
-							pThis->iSNDGeneralSoundID = iSoundID;
-						}
-						bRet = L_PlaySound_SC2K1996((LPCSTR)pThis->dwSNDBufferGeneral, SND_ASYNC | SND_NODEFAULT | SND_MEMORY);
-					}
-				}*/
-				pThis->bSNDPlaySound = SoundEnginePlayStream(&pStreamCurrentSound, &mapSoundCache[iSoundID],
-					jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SOUNDVOLUME].ToFloat() * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MASTERVOLUME].ToFloat(),
-					true, (pThis->iSNDActionThingSoundID == iSoundID && pThis->dwSNDBufferActionThing ? true : false));
-				if (pThis->bSNDPlaySound) {
-					pThis->iSNDCurrSoundID = iSoundID;
-					if (pThis->bSNDWasPlaying && pThis->iSNDActionThingSoundID == iSoundID)
-						nActionThingSoundPlayTicks = 0;
-					else
-						nActionThingSoundPlayTicks = nSoundPlayTicksEntry;
-				}
-				else
-					Game_Sound_PlayPrioritySound(pThis);
+				L_PlaySound_SC2K1996(nAttrib, 0);
 			}
 		}
 	}
@@ -508,6 +467,8 @@ static bool LoadSoundFromFile(int iSoundID, std::string strPath) {
 	SF_INFO stSoundFileInfo;
 	audio_entity_t stAudioEntity;
 	SNDFILE* sndfile = SF_open(strPath.c_str(), SFM_READ, &stSoundFileInfo);
+
+	memset(&mapSoundCache[iSoundID], 0, sizeof(mapSoundCache[iSoundID]));
 
 	if (!sndfile) {
 		ConsoleLog(LOG_ERROR, "SND:  Couldn't load sound file \"%s\" (sndfile).\n", strPath.c_str());

--- a/hooks/hook_tilegrowthorplacement.cpp
+++ b/hooks/hook_tilegrowthorplacement.cpp
@@ -178,22 +178,6 @@ typedef struct {
 } tripStruct;
 #pragma pack(pop)
 
-// Recompilation helpers (TODO: wean off these)
-
-#define LAST_IND(x, type)	(sizeof(x) / sizeof(type) - 1)
-#define HIGH_IND(x, type)	LAST_IND(x,type)
-#define LOW_IND(x, type)	0
-#define SBYTEn(x, n)		(*((__int8*)&(x)+n))
-#define SWORDn(x, n)		(*((__int16*)&(x)+n))
-#define SDWORDn(x, n)		(*((__int32*)&(x)+n))
-
-#define SLOBYTE(x)				SBYTEn(x,LOW_IND(x,__int8))
-#define SLOWORD(x)				SWORDn(x,LOW_IND(x,__int16))
-#define SLODWORD(x)				SDWORDn(x,LOW_IND(x,__int32))
-#define SHIBYTE(x)				SBYTEn(x,HIGH_IND(x,__int8))
-#define SHIWORD(x)				SWORDn(x,HIGH_IND(x,__int16))
-#define SHIDWORD(x)				SDWORDn(x,HIGH_IND(x,__int32))
-
 static int iTotalTripCount = 0;
 
 // This is REALLY rough and has only had enough cleanup to make sense in my head so it probably

--- a/hooks/hook_toolbars.cpp
+++ b/hooks/hook_toolbars.cpp
@@ -97,13 +97,7 @@ extern "C" void __stdcall Hook_CityToolBar_OnLButtonDown(UINT nFlags, CMFC3XPoin
 			Game_SimcityApp_SoundPlaySound(pSCApp, SOUND_ERROR);
 			return;
 		}
-
-		// Bug workaround: Playing sound on this toolbar button can cause deadlocks when using the
-		// native Windows MIDI sequencer on some machines. It may also affect MP3 and FluidSynth,
-		// we aren't completely sure.
-		if (iHitMenuButton != CITYTOOL_BUTTON_BUDGET)
-			Game_SimcityApp_SoundPlaySound(pSCApp, SOUND_CLICK);
-
+		Game_SimcityApp_SoundPlaySound(pSCApp, SOUND_CLICK);
 		hSubMenu = GetSubMenu(pThis->dwCTBMenuOne.m_hMenu, pThis->iMyTBMenuButtonPos);
 		pSubMenu = GameMain_Menu_FromHandle(hSubMenu);
 		if (pSubMenu) {

--- a/include/music.h
+++ b/include/music.h
@@ -15,6 +15,7 @@ enum {
 };
 
 void InstallMusicEngineHooks(void);
+const char *GetGameMusicSoundPath(int iSongID, BOOL bDoMP3);
 DWORD WINAPI MusicThread(LPVOID lpParameter);
 void MusicShufflePlaylist(int iLastSongPlayed);
 

--- a/include/sc2k_1996.h
+++ b/include/sc2k_1996.h
@@ -2996,6 +2996,7 @@ GAMECALL(0x4014CE, int, __cdecl, SpawnAeroplane, __int16 x, __int16 y, __int16 i
 GAMECALL(0x4014EC, void, __cdecl, CityToolPlaceNature, CMFC3XPoint)
 GAMECALL(0x4014F1, int, __thiscall, SimcityView_TileHighlightRemove, CSimcityView *pThis)
 GAMECALL(0x40150A, int, __thiscall, SimcityApp_ExitRequester, CSimcityAppPrimary *pThis, int iSource)
+GAMECALL(0x401514, void, __stdcall, PerhapsFreeDocumentsLibraryAndStrings)
 GAMECALL(0x401519, void, __thiscall, CityToolBar_ToolMenuEnable, CCityToolBar* pThis)
 GAMECALL(0x40152D, BOOL, __thiscall, SimcityView_MainWindowUpdate, CSimcityView *, RECT *, BOOL)
 GAMECALL(0x401573, int, __thiscall, SimcityView_CityToolPlaceSubway, CSimcityView*, __int16, __int16)
@@ -3304,6 +3305,7 @@ GAMECALL_MAIN(0x4BA2E5, CMFC3XView *, __thiscall, FrameWnd_GetActiveView, CMFC3X
 GAMECALL_MAIN(0x4BA3A0, void, __thiscall, FrameWnd_ShowControlBar, CMFC3XFrameWnd *pThis, CMFC3XControlBar *pBar, BOOL, int)
 GAMECALL_MAIN(0x4BA38B, CMFC3XDocument *, __thiscall, FrameWnd_GetActiveDocument, CMFC3XFrameWnd *)
 GAMECALL_MAIN(0x4BB23A, void, __thiscall, FrameWnd_RecalcLayout, CMFC3XFrameWnd *pThis, int)
+GAMECALL_MAIN(0x4BE492, void, __thiscall, WinApp_ExitInstance, CMFC3XWinApp *)
 GAMECALL_MAIN(0x4BE7F7, void, __thiscall, WinApp_EnableShellOpen, CMFC3XWinApp *)
 GAMECALL_MAIN(0x4C0730, MFC3X_AFX_THREAD_STATE *, __stdcall, AfxGetThreadState, void)
 
@@ -4386,9 +4388,14 @@ extern std::vector<sprite_ids_t> spriteIDs;
 
 extern HWND hwndMainDialog_SC2K1996;
 
+extern bool bSoundKickstart;
+
+extern int GetSoundPlayTicksBySoundID_SC2K1996(int iSoundID);
+extern int GetTickDurationBySoundID_SC2K1996(int iSoundID, int nDuration);
+
 extern void ResetCheatInput_SC2K1996();
 
-extern BOOL L_PlaySound_SC2K1996(LPCTSTR pszSound, UINT fuSound);
+extern void L_PlaySound_SC2K1996(int nAttrib, int nDuration);
 extern void L_PlayToolSound_SC2K1996(CSimcityAppPrimary *pSCApp, int iSoundID = 0);
 
 extern void DumpMapThings_SC2K1996();

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -90,6 +90,30 @@ template <typename T> std::string to_string_precision(const T value, const int p
 #define WORD_OFFSETOF(ty, el)  SIZE_OFFSETOF(WORD, ty, el)
 #define BYTE_OFFSETOF(ty, el)  SIZE_OFFSETOF(BYTE, ty, el)
 
+// Recompilation helpers - useful in various places - moved here
+#define LAST_IND(x, type)	(sizeof(x) / sizeof(type) - 1)
+#define HIGH_IND(x, type)	LAST_IND(x,type)
+#define LOW_IND(x, type)	0
+#define UBYTEn(x, n)		(*((uint8_t*)&(x)+n))
+#define UWORDn(x, n)		(*((uint16_t*)&(x)+n))
+#define UDWORDn(x, n)		(*((uint32_t*)&(x)+n))
+#define SBYTEn(x, n)		(*((__int8*)&(x)+n))
+#define SWORDn(x, n)		(*((__int16*)&(x)+n))
+#define SDWORDn(x, n)		(*((__int32*)&(x)+n))
+
+#define ULOBYTE(x)			UBYTEn(x,LOW_IND(x,uint8_t))
+#define ULOWORD(x)			UWORDn(x,LOW_IND(x,uint16_t))
+#define ULODWORD(x)			UDWORDn(x,LOW_IND(x,uint32_t))
+#define UHIBYTE(x)			UBYTEn(x,HIGH_IND(x,uint8_t))
+#define UHIWORD(x)			UWORDn(x,HIGH_IND(x,uint16_t))
+#define UHIDWORD(x)			UDWORDn(x,HIGH_IND(x,uint32_t))
+#define SLOBYTE(x)			SBYTEn(x,LOW_IND(x,__int8))
+#define SLOWORD(x)			SWORDn(x,LOW_IND(x,__int16))
+#define SLODWORD(x)			SDWORDn(x,LOW_IND(x,__int32))
+#define SHIBYTE(x)			SBYTEn(x,HIGH_IND(x,__int8))
+#define SHIWORD(x)			SWORDn(x,HIGH_IND(x,__int16))
+#define SHIDWORD(x)			SDWORDn(x,HIGH_IND(x,__int32))
+
 #define IFF_HEAD(a, b, c, d) ((DWORD)d << 24 | (DWORD)c << 16 | (DWORD)b << 8 | (DWORD)a)
 #define DWORD_NTOHL_CHECK(x) (bBigEndian ? ntohl(x) : x)
 #define DWORD_HTONL_CHECK(x) (bBigEndian ? htonl(x) : x)

--- a/include/sound_engine.h
+++ b/include/sound_engine.h
@@ -6,6 +6,13 @@
 #include <sc2kfix.h>
 #include "../thirdparty/sndfile.h"
 
+#define WM_SDL_STOP	WM_APP+1
+#define WM_SDL_PLAY	WM_APP+2
+
+#define SND_ORIG_ACTSND_EXIST  0
+#define SND_ORIG_ACTSND_NONBUF 1
+#define SND_ORIG_PLAYSND       2
+
 // covers what we need in sc2kfix
 typedef enum SDL_AudioFormat {
 	SDL_AUDIO_UNKNOWN = 0x0000u,
@@ -44,6 +51,11 @@ typedef struct {
 	sf_count_t iOffset;
 } SF_viodata;
 
+typedef struct {
+	__int16 iSoundID;
+	__int16 nOrig;
+} gameSoundAttrib_t;
+
 typedef uint32_t SDL_InitFlags;
 typedef void SDL_AudioStream;
 typedef uint32_t SDL_AudioDeviceID;
@@ -57,6 +69,9 @@ extern HMODULE hmodSDL3;
 extern SDL_AudioStream* pStreamCurrentSong;
 extern SDL_AudioStream* pStreamCurrentSound;
 
+extern DWORD dwSDLSoundThreadID;
+extern DWORD dwSDLSongThreadID;
+
 extern SNDFILE* (*SF_open)(const char* path, int mode, SF_INFO* sfinfo);
 extern SNDFILE* (*SF_open_virtual)(SF_VIRTUAL_IO* sfvirtual, int mode, SF_INFO* sfinfo, void* user_data);
 extern sf_count_t(*SF_seek)(SNDFILE* sndfile, sf_count_t frames, int whence);
@@ -64,17 +79,23 @@ extern int (*SF_close)(SNDFILE* sndfile);
 extern sf_count_t(*SF_readf_short)(SNDFILE* sndfile, short* ptr, sf_count_t frames);
 
 extern bool (*SDL_Init)(SDL_InitFlags flags);
+extern bool (*SDL_ClearAudioStream)(SDL_AudioStream* stream);
 extern void (*SDL_DestroyAudioStream)(SDL_AudioStream* stream);
 extern SDL_AudioStream* (*SDL_OpenAudioDeviceStream)(SDL_AudioDeviceID devid, const SDL_AudioSpec* spec, SDL_AudioStreamCallback callback, void* userdata);
 extern bool (*SDL_PutAudioStreamData)(SDL_AudioStream* stream, const void* buf, int len);
 extern bool (*SDL_ResumeAudioStreamDevice)(SDL_AudioStream* stream);
 extern int (*SDL_GetAudioStreamAvailable)(SDL_AudioStream* stream);
+extern bool (*SDL_SetAudioStreamFormat)(SDL_AudioStream* stream, SDL_AudioSpec* src_spec, SDL_AudioSpec* dst_spec);
 extern const char* (*SDL_GetError)(void);
 extern bool (*SDL_MixAudio)(uint8_t* dst, const uint8_t* src, SDL_AudioFormat format, uint32_t len, float volume);
 extern bool (*SDL_SetAudioStreamGain)(SDL_AudioStream* stream, float gain);
 
+DWORD WINAPI SDLSoundThread(LPVOID lpParameter);
+DWORD WINAPI SDLSongThread(LPVOID lpParameter);
+
 bool LoadSoundEngineLibraries(void);
 bool SoundEngineInitialize(void);
+void SoundEngineDestroy(void);
 void SoundEngineStopStream(SDL_AudioStream** pStream);
 bool SoundEnginePlayStream(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume, bool bOverride, bool bLoop);
 void SoundEngineStopSong(SDL_AudioStream** pStream);

--- a/modules/console_new.cpp
+++ b/modules/console_new.cpp
@@ -484,10 +484,11 @@ bool ConsoleCommandRunTest(std::vector<std::string> args, int iBreakoutState, in
 	if (iBreakoutState != BREAKOUT_RETURN)
 		return false;
 
-	if (pStreamCurrentSound)
-		SoundEngineStopStream(&pStreamCurrentSound);
-	else
-		SoundEnginePlayStream(&pStreamCurrentSound, &mapSoundCache[SOUND_ZAP], 1.0, false, true);
+	int nAttrib;
+
+	ULOWORD(nAttrib) = SOUND_ZAP;
+	UHIWORD(nAttrib) = SND_ORIG_PLAYSND;
+	L_PlaySound_SC2K1996(nAttrib, 0);
 	return true;
 }
 

--- a/modules/music.cpp
+++ b/modules/music.cpp
@@ -383,7 +383,7 @@ static BOOL ValidateFilename(const char *pName, const char *pExt) {
 	return FALSE;
 }
 
-static const char *GetGameSoundPath(int iSongID, BOOL bDoMP3) {
+const char *GetGameMusicSoundPath(int iSongID, BOOL bDoMP3) {
 	const char *pExt;
 	static std::string strSongPath;
 	BOOL bUseAliasedSong;
@@ -419,8 +419,6 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 	CSimcityAppPrimary *pSCApp;
 	MSG msg;
 	MCIERROR dwMCIError = NULL;
-	SF_INFO stInfoMP3File = { 0 };
-	audio_entity_t stAudioEntityMP3 = { 0 };
 
 	if (mus_debug & MUS_DEBUG_THREAD)
 		ConsoleLog(LOG_DEBUG, "MUS:  Starting music engine! Initial music driver set to \"%s\".\n", jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString().c_str());
@@ -448,9 +446,7 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 
 			// If we're playing an MP3, stop it and unload it from memory
 			if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() == "mp3") {
-				SoundEngineStopSong(&pStreamCurrentSong);
-				free(stAudioEntityMP3.pBuffer);
-				memset(&stAudioEntityMP3, 0, sizeof(audio_entity_t));
+				PostThreadMessageA(dwSDLSongThreadID, WM_SDL_STOP, 0, 0);
 				if (mus_debug & MUS_DEBUG_THREAD)
 					ConsoleLog(LOG_DEBUG, "MUS:  Thread stopped MP3 playback due to WM_MUSIC_STOP message.\n");
 				goto next;
@@ -491,9 +487,9 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 				if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() == "fluidsynth" && hmodFluidSynth) {
 					if (msg.wParam >= 10000 && msg.wParam <= 10018) {
 						iPlayingSongID = msg.wParam;
-						char* szSongPath = _strdup(GetGameSoundPath(iPlayingSongID, FALSE));
+						char* szSongPath = _strdup(GetGameMusicSoundPath(iPlayingSongID, FALSE));
 						if (mus_debug & MUS_DEBUG_FLUIDSYNTH)
-							ConsoleLog(LOG_DEBUG, "MUS:  GetGameSoundPath(%d, FALSE) returned \"%s\".\n", iPlayingSongID, szSongPath);
+							ConsoleLog(LOG_DEBUG, "MUS:  GetGameMusicSoundPath(%d, FALSE) returned \"%s\".\n", iPlayingSongID, szSongPath);
 
 						if (szSongPath && !bFluidSynthPlaying)
 							CreateThread(NULL, 0, FluidSynthWatchdogThread, (LPVOID)szSongPath, 0, NULL);
@@ -507,46 +503,10 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 				if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() == "mp3") {
 					if (msg.wParam >= 10000 && msg.wParam <= 10018) {
 						iPlayingSongID = msg.wParam;
-						const char* szSongPath = GetGameSoundPath(iPlayingSongID, TRUE);
+						const char* szSongPath = GetGameMusicSoundPath(iPlayingSongID, TRUE);
 
 						if (szSongPath) {
-							//uint64_t uTickStart = GetTickCount64();
-							LARGE_INTEGER uTickStart, uTickEnd, uTicksPerSecond;
-							QueryPerformanceFrequency(&uTicksPerSecond);
-							QueryPerformanceCounter(&uTickStart);
-							SNDFILE* sndfile = SF_open(szSongPath, SFM_READ, &stInfoMP3File);
-
-							if (!sndfile) {
-								ConsoleLog(LOG_ERROR, "MUS:  Couldn't load MP3 file \"%s\" (sndfile).\n", szSongPath);
-								return false;
-							}
-
-							// Build the audio entity data
-							stAudioEntityMP3.iFrames = stInfoMP3File.frames;
-							stAudioEntityMP3.iSampleRate = stInfoMP3File.samplerate;
-							stAudioEntityMP3.iChannels = stInfoMP3File.channels;
-							stAudioEntityMP3.iFormat = stInfoMP3File.format;
-							stAudioEntityMP3.bSeekable = stInfoMP3File.seekable;
-							stAudioEntityMP3.uBufferSize = stAudioEntityMP3.iChannels * sizeof(short) * stAudioEntityMP3.iFrames;
-							stAudioEntityMP3.pBuffer = (short*)malloc(stAudioEntityMP3.uBufferSize);
-							if (!stAudioEntityMP3.pBuffer) {
-								ConsoleLog(LOG_ERROR, "MUS:  Couldn't load MP3 file \"%s\" (malloc).\n", szSongPath);
-								return false;
-							}
-
-							// Read the audio into the buffer as 16-bit PCM
-							SF_readf_short(sndfile, stAudioEntityMP3.pBuffer, stAudioEntityMP3.iFrames);
-							SF_close(sndfile);
-							QueryPerformanceCounter(&uTickEnd);
-							if (mus_debug & MUS_DEBUG_SONGS)
-								ConsoleLog(LOG_DEBUG, "MUS:  Loading MP3 file \"%s\" took %llu microseconds.\n", szSongPath, ((uTickEnd.QuadPart - uTickStart.QuadPart) * 1000000 / uTicksPerSecond.QuadPart));
-
-							// Start playing the song and finish processing this message
-							if (mus_debug & MUS_DEBUG_THREAD)
-								ConsoleLog(LOG_DEBUG, "MUS:  Playing MP3 file \"%s\" via SDL3.\n", szSongPath);
-							SoundEnginePlaySong(&pStreamCurrentSong, &stAudioEntityMP3,
-								jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICVOLUME].ToFloat() * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MASTERVOLUME].ToFloat(),
-								true);
+							PostThreadMessageA(dwSDLSongThreadID, WM_SDL_PLAY, iPlayingSongID, 0);
 							goto next;
 						} else
 							ConsoleLog(LOG_ERROR, "MUS:  Could not find music file %s; failing back to MIDI sequencer.\n", szSongPath);
@@ -557,7 +517,7 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 				if (!mciDevice) {
 					if (msg.wParam >= 10000 && msg.wParam <= 10018) {
 						iPlayingSongID = msg.wParam;
-						const char* szSongPath = GetGameSoundPath(iPlayingSongID, FALSE);
+						const char* szSongPath = GetGameMusicSoundPath(iPlayingSongID, FALSE);
 						
 						if (!szSongPath)
 							goto next;
@@ -608,9 +568,7 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 			}
 
 			if (pStreamCurrentSong) {
-				SoundEngineStopSong(&pStreamCurrentSong);
-				free(stAudioEntityMP3.pBuffer);
-				memset(&stAudioEntityMP3, 0, sizeof(audio_entity_t));
+				PostThreadMessageA(dwSDLSongThreadID, WM_SDL_STOP, 0, 0);
 				if (mus_debug & MUS_DEBUG_THREAD)
 					ConsoleLog(LOG_DEBUG, "MUS:  Thread stopped MP3 player due to WM_MUSIC_RESET message.\n");
 			}

--- a/modules/sound_engine.cpp
+++ b/modules/sound_engine.cpp
@@ -15,6 +15,22 @@
 #include "../resource.h"
 #include "../thirdparty/sndfile.h"
 
+#define SDL_DEBUG_GENERAL 1
+#define SDL_DEBUG_THREADS 2
+#define SDL_DEBUG_SOUND 4
+#define SDL_DEBUG_SONG 8
+
+#define SDL_DEBUG DEBUG_FLAGS_NONE
+
+#ifdef DEBUGALL
+#undef SDL_DEBUG
+#define SDL_DEBUG DEBUG_FLAGS_EVERYTHING
+#endif
+
+UINT sdl_debug = SDL_DEBUG;
+
+extern std::map<int, audio_entity_t> mapSoundCache;
+
 SNDFILE* (*SF_open)(const char* path, int mode, SF_INFO* sfinfo);
 SNDFILE* (*SF_open_virtual)(SF_VIRTUAL_IO* sfvirtual, int mode, SF_INFO* sfinfo, void* user_data);
 sf_count_t(*SF_seek)(SNDFILE* sndfile, sf_count_t frames, int whence);
@@ -23,10 +39,12 @@ sf_count_t(*SF_readf_short)(SNDFILE* sndfile, short* ptr, sf_count_t frames);
 
 bool (*SDL_Init)(SDL_InitFlags flags);
 void (*SDL_DestroyAudioStream)(SDL_AudioStream* stream);
+bool (*SDL_ClearAudioStream)(SDL_AudioStream* stream);
 SDL_AudioStream* (*SDL_OpenAudioDeviceStream)(SDL_AudioDeviceID devid, const SDL_AudioSpec* spec, SDL_AudioStreamCallback callback, void* userdata);
 bool (*SDL_PutAudioStreamData)(SDL_AudioStream* stream, const void* buf, int len);
 bool (*SDL_ResumeAudioStreamDevice)(SDL_AudioStream* stream);
 int (*SDL_GetAudioStreamAvailable)(SDL_AudioStream* stream);
+bool (*SDL_SetAudioStreamFormat)(SDL_AudioStream* stream, SDL_AudioSpec* src_spec, SDL_AudioSpec* dst_spec);
 const char* (*SDL_GetError)(void);
 bool (*SDL_MixAudio)(uint8_t* dst, const uint8_t* src, SDL_AudioFormat format, uint32_t len, float volume);
 bool (*SDL_SetAudioStreamGain)(SDL_AudioStream* stream, float gain);
@@ -34,43 +52,292 @@ bool (*SDL_SetAudioStreamGain)(SDL_AudioStream* stream, float gain);
 HMODULE hmodSndFile = NULL;
 HMODULE hmodSDL3 = NULL;
 
+DWORD dwSDLSoundThreadID = 0;
+DWORD dwSDLSongThreadID = 0;
+
 int iCurrentSongID = 0;
 int iCurrentSoundID = 0;
 SDL_AudioStream* pStreamCurrentSong = NULL;
 SDL_AudioStream* pStreamCurrentSound = NULL;
 HANDLE hCurrentSongThread = NULL;
 HANDLE hCurrentSoundThread = NULL;
+bool bSongPlaying = false;
+bool bSoundPlaying = false;
+
+bool bSongStop = false;
+bool bSoundStop = false;
+
+bool bSongThreadActive = false;
+bool bSoundThreadActive[2] = { false, false };
+
+#define MAX_START 35
+
+static void StopCurrentSound(SDL_AudioStream** pStream) {
+	if (*pStream) {
+		if (bSoundThreadActive[0] || bSoundThreadActive[1]) {
+			if (hCurrentSoundThread) {
+				int i = 0;
+
+				if (bSoundThreadActive[0]) {
+					bSoundStop = true;
+					for (i=MAX_START; i>0; i--)
+					{
+						if (!bSoundThreadActive[0]) break;
+						Sleep(100);
+					}
+				}
+				else if (bSoundThreadActive[1]) {
+					bSoundStop = true;
+					for (i=MAX_START; i>0; i--)
+					{
+						if (!bSoundThreadActive[1]) break;
+						Sleep(100);
+					}
+				}
+
+				DWORD dwThreadID = GetThreadId(hCurrentSoundThread);
+				if (dwThreadID) {
+					if (!TerminateThread(hCurrentSoundThread, EXIT_SUCCESS))
+						ConsoleLog(LOG_DEBUG, "StopCurrentSound(): Hmmm... 0x%06X\n", GetLastError());
+					else
+						hCurrentSoundThread = 0;
+				}
+			}
+			SoundEngineStopStream(pStream);
+		}
+	}
+}
+
+DWORD WINAPI SDLSoundThread(LPVOID lpParameter) {
+	MSG msg;
+	int nDuration;
+	gameSoundAttrib_t soundAttrib;
+	float fVolume;
+	bool bLoop;
+	CSimcityAppPrimary *pSCApp;
+	CSound *pSound;
+
+	if (sdl_debug & SDL_DEBUG_THREADS)
+		ConsoleLog(LOG_DEBUG, "SND:  Starting SDL Sound Thread!\n");
+
+	while (GetMessage(&msg, NULL, 0, 0)) {
+		if (msg.message == WM_SDL_PLAY) {
+			nDuration = (int)msg.wParam;
+			soundAttrib.iSoundID = LOWORD(msg.lParam);
+			soundAttrib.nOrig = HIWORD(msg.lParam);
+			if (sdl_debug & SDL_DEBUG_SOUND)
+				ConsoleLog(LOG_DEBUG, "SDLSoundThread: WM_SDL_PLAY: (%d) (%d) %d\n", soundAttrib.iSoundID, nDuration, soundAttrib.nOrig);
+			
+			fVolume = jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SOUNDVOLUME].ToFloat() * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MASTERVOLUME].ToFloat();
+
+			pSCApp = &pCSimcityAppThis;
+			if (pSCApp) {
+				pSound = pSCApp->SCASNDLayer;
+				if (soundAttrib.nOrig == SND_ORIG_ACTSND_EXIST) {
+					if (SoundEnginePlayStream(&pStreamCurrentSound, &mapSoundCache[soundAttrib.iSoundID], fVolume, true, true)) {
+						pSound->iSNDActionThingSoundID = soundAttrib.iSoundID;
+						pSound->iSNDCurrSoundID = soundAttrib.iSoundID;
+						pSound->bSNDPlaySound = TRUE;
+						pSound->bSNDWasPlaying = TRUE;
+						nActionThingSoundPlayTicks = (nDuration <= 0) ? 0 : GetTickDurationBySoundID_SC2K1996(soundAttrib.iSoundID, nDuration);
+						if (sdl_debug & SDL_DEBUG_SOUND)
+							ConsoleLog(LOG_DEBUG, "SDLSoundThread: Sound(%d), Duration(%d), nActionThingSoundPlayTicks(%d)\n", soundAttrib.iSoundID, nDuration, nActionThingSoundPlayTicks);
+					}
+					else
+						pSound->bSNDWasPlaying = FALSE;
+				}
+				else if (soundAttrib.nOrig == SND_ORIG_ACTSND_NONBUF) {
+					pSound->bSNDPlaySound = SoundEnginePlayStream(&pStreamCurrentSound, &mapSoundCache[soundAttrib.iSoundID], fVolume, true, true);
+					nActionThingSoundPlayTicks = (nDuration <= 0) ? 0 : GetTickDurationBySoundID_SC2K1996(soundAttrib.iSoundID, nDuration);
+					pSound->iSNDCurrSoundID = soundAttrib.iSoundID;
+					pSound->bSNDWasPlaying = pSound->bSNDPlaySound;
+				}
+				else if (soundAttrib.nOrig == SND_ORIG_PLAYSND) {
+					bLoop = (pSound->iSNDActionThingSoundID == soundAttrib.iSoundID && pSound->dwSNDBufferActionThing ? true : false);
+					pSound->bSNDPlaySound = SoundEnginePlayStream(&pStreamCurrentSound, &mapSoundCache[soundAttrib.iSoundID], fVolume, true, bLoop);
+					if (pSound->bSNDPlaySound) {
+						pSound->iSNDCurrSoundID = soundAttrib.iSoundID;
+						if (pSound->bSNDWasPlaying && pSound->iSNDActionThingSoundID == soundAttrib.iSoundID)
+							nActionThingSoundPlayTicks = 0;
+						else
+							nActionThingSoundPlayTicks = GetSoundPlayTicksBySoundID_SC2K1996(soundAttrib.iSoundID);
+					}
+					else
+						Game_Sound_PlayPrioritySound(pSound);
+				}
+			}
+		}
+		else if (msg.message == WM_SDL_STOP) {
+			StopCurrentSound(&pStreamCurrentSound);
+		}
+		else if (msg.message == WM_QUIT)
+			break;
+
+		DispatchMessage(&msg);
+	}
+
+	StopCurrentSound(&pStreamCurrentSound);
+	if (sdl_debug & SDL_DEBUG_THREADS)
+		ConsoleLog(LOG_INFO, "SND:  Shutting down SDL Sound thread.\n");
+	return EXIT_SUCCESS;
+}
+
+static void StopCurrentSong(SDL_AudioStream** pStream) {
+	if (*pStream) {
+		if (bSongThreadActive) {
+			if (hCurrentSongThread) {
+				int i = 0;
+
+				if (bSongThreadActive) {
+					bSongStop = true;
+					for (i=MAX_START; i>0; i--)
+					{
+						if (!bSongThreadActive) break;
+						Sleep(100);
+					}
+				}
+
+				DWORD dwThreadID = GetThreadId(hCurrentSongThread);
+				if (dwThreadID) {
+					if (!TerminateThread(hCurrentSongThread, EXIT_SUCCESS))
+						ConsoleLog(LOG_DEBUG, "StopCurrentSong(): Hmmm... 0x%06X\n", GetLastError());
+					else
+						hCurrentSongThread = 0;
+				}
+			}
+			SoundEngineStopSong(pStream);
+		}
+	}
+}
+
+DWORD WINAPI SDLSongThread(LPVOID lpParameter) {
+	MSG msg;
+	SF_INFO stInfoMP3File = { 0 };
+	audio_entity_t stAudioEntityMP3 = { 0 };
+
+	if (sdl_debug & SDL_DEBUG_THREADS)
+		ConsoleLog(LOG_DEBUG, "SND:  Starting SDL Song thread!\n");
+
+	while (GetMessage(&msg, NULL, 0, 0)) {
+		if (msg.message == WM_SDL_PLAY) {
+			int iPlayingSongID = (int)msg.wParam;
+			if (iPlayingSongID >= 10000 && iPlayingSongID <= 10018) {
+				if (bSongPlaying)
+					goto next;
+				const char* szSongPath = GetGameMusicSoundPath(iPlayingSongID, TRUE);
+				if (szSongPath) {
+					//uint64_t uTickStart = GetTickCount64();
+					LARGE_INTEGER uTickStart, uTickEnd, uTicksPerSecond;
+					QueryPerformanceFrequency(&uTicksPerSecond);
+					QueryPerformanceCounter(&uTickStart);
+					SNDFILE* sndfile = SF_open(szSongPath, SFM_READ, &stInfoMP3File);
+
+					if (!sndfile) {
+						ConsoleLog(LOG_ERROR, "MUS:  Couldn't load MP3 file \"%s\" (sndfile).\n", szSongPath);
+						goto next;
+					}
+
+					// Build the audio entity data
+					stAudioEntityMP3.iFrames = stInfoMP3File.frames;
+					stAudioEntityMP3.iSampleRate = stInfoMP3File.samplerate;
+					stAudioEntityMP3.iChannels = stInfoMP3File.channels;
+					stAudioEntityMP3.iFormat = stInfoMP3File.format;
+					stAudioEntityMP3.bSeekable = stInfoMP3File.seekable;
+					stAudioEntityMP3.uBufferSize = stAudioEntityMP3.iChannels * sizeof(short) * stAudioEntityMP3.iFrames;
+					stAudioEntityMP3.pBuffer = (short*)malloc(stAudioEntityMP3.uBufferSize);
+					if (!stAudioEntityMP3.pBuffer) {
+						ConsoleLog(LOG_ERROR, "MUS:  Couldn't load MP3 file \"%s\" (malloc).\n", szSongPath);
+						goto next;
+					}
+
+					// Read the audio into the buffer as 16-bit PCM
+					SF_readf_short(sndfile, stAudioEntityMP3.pBuffer, stAudioEntityMP3.iFrames);
+					SF_close(sndfile);
+					QueryPerformanceCounter(&uTickEnd);
+					if (sdl_debug & SDL_DEBUG_SONG)
+						ConsoleLog(LOG_DEBUG, "MUS:  Loading MP3 file \"%s\" took %llu microseconds.\n", szSongPath, ((uTickEnd.QuadPart - uTickStart.QuadPart) * 1000000 / uTicksPerSecond.QuadPart));
+
+					// Start playing the song and finish processing this message
+					if (sdl_debug & SDL_DEBUG_SONG)
+						ConsoleLog(LOG_DEBUG, "MUS:  Playing MP3 file \"%s\" via SDL3.\n", szSongPath);
+					SoundEnginePlaySong(&pStreamCurrentSong, &stAudioEntityMP3,
+						jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICVOLUME].ToFloat() * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MASTERVOLUME].ToFloat(),
+						true);
+				}
+			}
+		}
+		else if (msg.message == WM_SDL_STOP) {
+			StopCurrentSong(&pStreamCurrentSong);
+			free(stAudioEntityMP3.pBuffer);
+			memset(&stAudioEntityMP3, 0, sizeof(audio_entity_t));
+		}
+		else if (msg.message == WM_QUIT)
+			break;
+next:
+		DispatchMessage(&msg);
+	}
+
+	StopCurrentSong(&pStreamCurrentSong);
+	free(stAudioEntityMP3.pBuffer);
+	memset(&stAudioEntityMP3, 0, sizeof(audio_entity_t));
+	if (sdl_debug & SDL_DEBUG_THREADS)
+		ConsoleLog(LOG_INFO, "SND:  Shutting down SDL Song thread.\n");
+	return EXIT_SUCCESS;
+}
 
 DWORD WINAPI SoundEngineOneShotThread(LPVOID lpParameter) {
 	audio_entity_t* stAudioData = (audio_entity_t*)lpParameter;
 
-	while (SDL_GetAudioStreamAvailable(pStreamCurrentSound) > 0)
+	if (bSoundThreadActive[0])
+		return EXIT_SUCCESS;
+	bSoundThreadActive[0] = true;
+	bSoundStop = false;
+	while (SDL_GetAudioStreamAvailable(pStreamCurrentSound) > 0) {
+		if (bSoundStop)
+			break;
 		Sleep(10);
+	}
 
-	pStreamCurrentSound = NULL;
+	bSoundThreadActive[0] = false;
+	bSoundPlaying = false;
 	return EXIT_SUCCESS;
 }
 DWORD WINAPI SoundEngineSongThread(LPVOID lpParameter) {
 	audio_entity_t* stAudioData = (audio_entity_t*)lpParameter;
 
-	while (SDL_GetAudioStreamAvailable(pStreamCurrentSong) > 0)
+	if (bSongThreadActive)
+		return EXIT_SUCCESS;
+	bSongThreadActive = true;
+	bSongStop = false;
+	while (SDL_GetAudioStreamAvailable(pStreamCurrentSong) > 0) {
+		if (bSongStop)
+			break;
 		Sleep(10);
+	}
 
-	pStreamCurrentSong = NULL;
+	bSongThreadActive = false;
+	bSongPlaying = false;
 	return EXIT_SUCCESS;
 }
 
 DWORD WINAPI SoundEngineLoopThread(LPVOID lpParameter) {
 	audio_entity_t* stAudioData = (audio_entity_t*)lpParameter;
 
+	if (bSoundThreadActive[1])
+		return EXIT_SUCCESS;
+	bSoundThreadActive[1] = true;
+	bSoundStop = false;
 	for (;;) {
-		if (!pStreamCurrentSound)
+		if (bSoundStop)
+			break;
+		if (!bSoundPlaying || !pStreamCurrentSound)
 			return EXIT_SUCCESS;
 		if (SDL_GetAudioStreamAvailable(pStreamCurrentSound) < stAudioData->uBufferSize)
 			SDL_PutAudioStreamData(pStreamCurrentSound, stAudioData->pBuffer, stAudioData->uBufferSize);
 		Sleep(10);
 	}
 
+	bSoundThreadActive[1] = false;
 	return EXIT_SUCCESS;
 }
 
@@ -94,12 +361,14 @@ bool LoadSoundEngineLibraries(void) {
 	}
 
 	SDL_Init = (decltype(SDL_Init))GetProcAddress(hmodSDL3, "SDL_Init");
+	SDL_ClearAudioStream = (decltype(SDL_ClearAudioStream))GetProcAddress(hmodSDL3, "SDL_ClearAudioStream");
 	SDL_DestroyAudioStream = (decltype(SDL_DestroyAudioStream))GetProcAddress(hmodSDL3, "SDL_DestroyAudioStream");
 	SDL_OpenAudioDeviceStream = (decltype(SDL_OpenAudioDeviceStream))GetProcAddress(hmodSDL3, "SDL_OpenAudioDeviceStream");
 	SDL_PutAudioStreamData = (decltype(SDL_PutAudioStreamData))GetProcAddress(hmodSDL3, "SDL_PutAudioStreamData");
 	SDL_ResumeAudioStreamDevice = (decltype(SDL_ResumeAudioStreamDevice))GetProcAddress(hmodSDL3, "SDL_ResumeAudioStreamDevice");
 	SDL_GetAudioStreamAvailable = (decltype(SDL_GetAudioStreamAvailable))GetProcAddress(hmodSDL3, "SDL_GetAudioStreamAvailable");
 	SDL_GetError = (decltype(SDL_GetError))GetProcAddress(hmodSDL3, "SDL_GetError");
+	SDL_SetAudioStreamFormat = (decltype(SDL_SetAudioStreamFormat))GetProcAddress(hmodSDL3, "SDL_SetAudioStreamFormat");
 	SDL_MixAudio = (decltype(SDL_MixAudio))GetProcAddress(hmodSDL3, "SDL_MixAudio");
 	SDL_SetAudioStreamGain = (decltype(SDL_SetAudioStreamGain))GetProcAddress(hmodSDL3, "SDL_SetAudioStreamGain");
 	return true;
@@ -112,28 +381,48 @@ bool SoundEngineInitialize(void) {
 		return false;
 	}
 
+	if (sdl_debug & SDL_DEBUG_GENERAL)
+		ConsoleLog(LOG_DEBUG, "SND: SDL Sound Engine Initialized.\n");
+
+	// Create the two audio streams with default settings
+	SDL_AudioSpec spec = {
+		SDL_AUDIO_S16,
+		2,
+		44100
+	};
+	pStreamCurrentSong = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
+	pStreamCurrentSound = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
+
 	return true;
+}
+
+void SoundEngineDestroy(void) {
+	if (pStreamCurrentSong)
+		SDL_DestroyAudioStream(pStreamCurrentSong);
+	if (pStreamCurrentSound)
+		SDL_DestroyAudioStream(pStreamCurrentSound);
+
+	if (sdl_debug & SDL_DEBUG_GENERAL)
+		ConsoleLog(LOG_DEBUG, "SND: SDL Sound Engine Destroyed.\n");
 }
 
 void SoundEngineStopStream(SDL_AudioStream** pStream) {
 	if (!pStream)
 		return;
 	if (*pStream)
-		SDL_DestroyAudioStream(*pStream);
-	if (hCurrentSoundThread)
-		TerminateThread(hCurrentSoundThread, EXIT_SUCCESS);
+		SDL_ClearAudioStream(*pStream);
 
-	*pStream = NULL;
+	bSoundPlaying = false;
 }
 
 bool SoundEnginePlayStream(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume, bool bOverride, bool bLoop) {
 	if (!pStream || !stAudioData)
 		return false;
 
-	if (!bOverride && *pStream)
+	if (!bOverride && bSoundPlaying)
 		return false;
-	else if (*pStream)
-		SoundEngineStopStream(pStream);
+	
+	StopCurrentSound(pStream);
 
 	SDL_AudioSpec spec = {
 		SDL_AUDIO_S16,
@@ -141,13 +430,15 @@ bool SoundEnginePlayStream(SDL_AudioStream** pStream, audio_entity_t* stAudioDat
 		stAudioData->iSampleRate
 	};
 
-	*pStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
+	/**pStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
 	if (!*pStream)
-		ConsoleLog(LOG_ERROR, "SND:  SDL_OpenAudioDeviceStream failed: %s.\n", SDL_GetError());
+		ConsoleLog(LOG_ERROR, "SND:  SDL_OpenAudioDeviceStream failed: %s.\n", SDL_GetError());*/
 
+	SDL_SetAudioStreamFormat(*pStream, &spec, NULL);
 	SDL_SetAudioStreamGain(*pStream, fVolume);
 	SDL_PutAudioStreamData(*pStream, stAudioData->pBuffer, stAudioData->uBufferSize);
 	SDL_ResumeAudioStreamDevice(*pStream);
+	bSoundPlaying = true;
 
 	if (bLoop)
 		hCurrentSoundThread = CreateThread(NULL, 0, SoundEngineLoopThread, stAudioData, 0, NULL);
@@ -155,7 +446,7 @@ bool SoundEnginePlayStream(SDL_AudioStream** pStream, audio_entity_t* stAudioDat
 		hCurrentSoundThread = CreateThread(NULL, 0, SoundEngineOneShotThread, stAudioData, 0, NULL);
 
 	if (!hCurrentSoundThread) {
-		SoundEngineStopStream(pStream);
+		StopCurrentSound(pStream);
 		return false;
 	}
 
@@ -167,21 +458,19 @@ void SoundEngineStopSong(SDL_AudioStream** pStream) {
 	if (!pStream)
 		return;
 	if (*pStream)
-		SDL_DestroyAudioStream(*pStream);
-	if (hCurrentSongThread)
-		TerminateThread(hCurrentSongThread, EXIT_SUCCESS);
+		SDL_ClearAudioStream(*pStream);
 
-	*pStream = NULL;
+	bSongPlaying = false;
 }
 
 bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume, bool bOverride) {
 	if (!pStream || !stAudioData)
 		return false;
 
-	if (!bOverride && *pStream)
+	if (!bOverride && bSongPlaying)
 		return false;
-	else if (*pStream)
-		SoundEngineStopSong(pStream);
+	
+	StopCurrentSong(pStream);
 
 	SDL_AudioSpec spec = {
 		SDL_AUDIO_S16,
@@ -189,18 +478,19 @@ bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData,
 		stAudioData->iSampleRate
 	};
 
-	*pStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
+	/**pStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
 	if (!*pStream)
-		ConsoleLog(LOG_ERROR, "SND:  SDL_OpenAudioDeviceStream failed: %s.\n", SDL_GetError());
+		ConsoleLog(LOG_ERROR, "SND:  SDL_OpenAudioDeviceStream failed: %s.\n", SDL_GetError());*/
 
 	SDL_SetAudioStreamGain(*pStream, fVolume);
 	SDL_PutAudioStreamData(*pStream, stAudioData->pBuffer, stAudioData->uBufferSize);
 	SDL_ResumeAudioStreamDevice(*pStream);
+	bSongPlaying = true;
 
 	hCurrentSongThread = CreateThread(NULL, 0, SoundEngineSongThread, stAudioData, 0, NULL);
 
 	if (!hCurrentSongThread) {
-		SoundEngineStopSong(pStream);
+		StopCurrentSong(pStream);
 		return false;
 	}
 


### PR DESCRIPTION
Threads for handling the SDL Sound and Song operations have been added.

Prior direct sound calls within the hooked functions have been relocated to the sound thread.

MP3 operations that utilise the SDL Song thread have also been moved there.