### PR TITLE
Enable the new cached sprites and effects in "Batch Mode"

### DIFF
--- a/hooks/hook_animation.cpp
+++ b/hooks/hook_animation.cpp
@@ -21,9 +21,7 @@ extern "C" void __cdecl Hook_ToggleColorCycling_SC2K1996(CMFC3XPalette *pPalette
 	CMFC3XDC *pDC;
 	CMFC3XPalette *pSelPal;
 	CSimcityView *pSCView;
-	CMapToolBar *pMapToolBar;
-	CCityToolBar *pCityToolBar;
-	BOOL bRedraw, bCityViewAnim;
+	BOOL bRedraw;
 
 	// Only redraw the relevant windows during:
 	// 1) Titlescreen image animation.
@@ -41,8 +39,6 @@ extern "C" void __cdecl Hook_ToggleColorCycling_SC2K1996(CMFC3XPalette *pPalette
 				if (pMainFrm) {
 					pSCView = Game_SimcityApp_PointerToCSimcityViewClass(pSCApp);
 					if (!pSCView)
-						bUseCycle = true;
-					else if (!bFrequentUpdates)
 						bUseCycle = true;
 
 					GetPaletteEntries((HPALETTE)pPalette->m_hObject, 0, 0x100, pPalAnimMain);
@@ -79,38 +75,12 @@ extern "C" void __cdecl Hook_ToggleColorCycling_SC2K1996(CMFC3XPalette *pPalette
 						bRedraw = FALSE;
 
 					if (bRedraw) {
-						pMapToolBar = &pMainFrm->dwMFMapToolBar;
-						pCityToolBar = &pMainFrm->dwMFCityToolBar;
-
-						// With this check, the redraw calls won't be made if either toolbar is being dragged.
-						// This avoids any bleeding that may occur as a result of the blitted border that will
-						// appear during this time.
-						//
-						// NOTE: The only side-effect is that during toolbar dragging no palette animation will
-						//       occur; this won't have any effect on the simulation itself since that is temporarily
-						//       suspended during city toolbar dragging (and it doesn't matter during the map toolbar
-						//       dragging case).
-						bCityViewAnim = TRUE;
-
-						if (pCityToolBar && pCityToolBar->dwCTBToolBarTitleDrag)
-							bCityViewAnim = FALSE;
-
-						if (pMapToolBar && pMapToolBar->dwMTBToolBarTitleDrag)
-							bCityViewAnim = FALSE;
-
-						if (CanUseFloatingStatusDialog() && bStatusDialogMoving)
-							bCityViewAnim = FALSE;
-
 						// CMainFrame m_hWnd - only call this specific redraw function before CSimcityView has been created.
 						// (ie, before any game has been started - palette animation on the image is disabled once the
 						// game window has been created)
 						
 						if (!pSCView)
 							RedrawWindow(pMainFrm->m_hWnd, NULL, NULL, RDW_INVALIDATE);
-						else {
-							if (bCityViewAnim && bUseCycle)
-								RedrawWindow(pSCView->m_hWnd, NULL, NULL, RDW_INVALIDATE);
-						}
 					}
 				}
 			}

--- a/hooks/hook_drawing.cpp
+++ b/hooks/hook_drawing.cpp
@@ -1731,11 +1731,9 @@ static BYTE *Get_SpriteFrame_Buffer(std::vector<spriteFrame_t> &frameCache, BYTE
 
 static BYTE *Get_SpriteCache_BaseBuffer(sprite_header_t *pShapePtr, __int16 nSpriteID) {
 	if (pShapePtr->wHeight > 1) {
-		if (bFrequentUpdates) {
-			BYTE *pSpriteBuf = Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprFrame, NULL, 0);
-			if (pSpriteBuf)
-				return pSpriteBuf;
-		}
+		BYTE *pSpriteBuf = Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprFrame, NULL, 0);
+		if (pSpriteBuf)
+			return pSpriteBuf;
 		return pShapePtr->sprOffset.sprPtr;
 	}
 	return NULL;
@@ -1745,55 +1743,53 @@ static BYTE *Get_SpriteCache_Buffer(sprite_header_t *pShapePtr, __int16 nSpriteI
 	int nType = PALCACHE_TYPE_NONE;
 
 	if (pShapePtr->wHeight > 1) {
-		if (bFrequentUpdates) {
-			int nFrmIdx = nCycleIdx % CACHED_FRAMES;
-			if (nFrmIdx < 0)
-				nFrmIdx = -nFrmIdx;
-			BYTE *pSpriteBuf = Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprFrame, NULL, nFrmIdx);
-			if (pSpriteBuf) {
-				if (bWeatherEffects && !bLoColor && !bOnTheFlyPalIdx) {
-					if (TreeSpritesCheck(nSpriteID)) {
-						if (WeatherCheck())
-							nType = PALCACHE_TYPE_TREES_SEASON_SNOW;
+		int nFrmIdx = nCycleIdx % CACHED_FRAMES;
+		if (nFrmIdx < 0)
+			nFrmIdx = -nFrmIdx;
+		BYTE *pSpriteBuf = Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprFrame, NULL, nFrmIdx);
+		if (pSpriteBuf) {
+			if (bWeatherEffects && !bLoColor && !bOnTheFlyPalIdx) {
+				if (TreeSpritesCheck(nSpriteID)) {
+					if (WeatherCheck())
+						nType = PALCACHE_TYPE_TREES_SEASON_SNOW;
 
-						if (AutWintSeasonCheck())
-							nType = (nType == PALCACHE_TYPE_TREES_SEASON_SNOW) ? PALCACHE_TYPE_TREES_SEASON_AUTUMNSNOW : PALCACHE_TYPE_TREES_SEASON_AUTUMN;
+					if (AutWintSeasonCheck())
+						nType = (nType == PALCACHE_TYPE_TREES_SEASON_SNOW) ? PALCACHE_TYPE_TREES_SEASON_AUTUMNSNOW : PALCACHE_TYPE_TREES_SEASON_AUTUMN;
 
-						if (nType == PALCACHE_TYPE_TREES_SEASON_AUTUMN)
-							return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprSeasonAutumnFrame, pSpriteBuf, nFrmIdx);
-						else if (nType == PALCACHE_TYPE_TREES_SEASON_AUTUMNSNOW)
-							return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprSeasonAutumnSnowFrame, pSpriteBuf, nFrmIdx);
-						else if (nType == PALCACHE_TYPE_TREES_SEASON_SNOW)
-							return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprSeasonSnowFrame, pSpriteBuf, nFrmIdx);
-					}
-					else if (TerrainSpritesCheck(nSpriteID)) {
-						if (WeatherCheck()) {
-							if (DeepWaterSpriteCheck(nSpriteID)) {
-								nType = (BlizzardCheck()) ? PALCACHE_TYPE_WATER_ICE_BLIZZARD : PALCACHE_TYPE_WATER_ICE;
-								if (nType == PALCACHE_TYPE_WATER_ICE)
-									return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprDeepWaterIceFrame, pSpriteBuf, nFrmIdx);
-								else if (nType == PALCACHE_TYPE_WATER_ICE_BLIZZARD)
-									return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprDeepWaterBlizzardFrame, pSpriteBuf, nFrmIdx);
-							}
-							else {
-								nType = (BlizzardCheck()) ? PALCACHE_TYPE_TERRAIN_SNOW_BLIZZARD : PALCACHE_TYPE_TERRAIN_SNOW;
-								if (nType == PALCACHE_TYPE_TERRAIN_SNOW)
-									return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprTerrainSnowFrame, pSpriteBuf, nFrmIdx);
-								else if (nType == PALCACHE_TYPE_TERRAIN_SNOW_BLIZZARD)
-									return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprTerrainBlizzardFrame, pSpriteBuf, nFrmIdx);
-							}
+					if (nType == PALCACHE_TYPE_TREES_SEASON_AUTUMN)
+						return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprSeasonAutumnFrame, pSpriteBuf, nFrmIdx);
+					else if (nType == PALCACHE_TYPE_TREES_SEASON_AUTUMNSNOW)
+						return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprSeasonAutumnSnowFrame, pSpriteBuf, nFrmIdx);
+					else if (nType == PALCACHE_TYPE_TREES_SEASON_SNOW)
+						return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprSeasonSnowFrame, pSpriteBuf, nFrmIdx);
+				}
+				else if (TerrainSpritesCheck(nSpriteID)) {
+					if (WeatherCheck()) {
+						if (DeepWaterSpriteCheck(nSpriteID)) {
+							nType = (BlizzardCheck()) ? PALCACHE_TYPE_WATER_ICE_BLIZZARD : PALCACHE_TYPE_WATER_ICE;
+							if (nType == PALCACHE_TYPE_WATER_ICE)
+								return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprDeepWaterIceFrame, pSpriteBuf, nFrmIdx);
+							else if (nType == PALCACHE_TYPE_WATER_ICE_BLIZZARD)
+								return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprDeepWaterBlizzardFrame, pSpriteBuf, nFrmIdx);
 						}
-					}
-					else if (ObjectGrassSpritesCheck(nSpriteID)) {
-						if (WeatherCheck()) {
-							nType = PALCACHE_GRASS_SNOW; // Yes I know.. this is the only option here currently.
-							if (nType == PALCACHE_GRASS_SNOW)
-								return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprGrassSnowFrame, pSpriteBuf, nFrmIdx);
+						else {
+							nType = (BlizzardCheck()) ? PALCACHE_TYPE_TERRAIN_SNOW_BLIZZARD : PALCACHE_TYPE_TERRAIN_SNOW;
+							if (nType == PALCACHE_TYPE_TERRAIN_SNOW)
+								return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprTerrainSnowFrame, pSpriteBuf, nFrmIdx);
+							else if (nType == PALCACHE_TYPE_TERRAIN_SNOW_BLIZZARD)
+								return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprTerrainBlizzardFrame, pSpriteBuf, nFrmIdx);
 						}
 					}
 				}
-				return pSpriteBuf;
+				else if (ObjectGrassSpritesCheck(nSpriteID)) {
+					if (WeatherCheck()) {
+						nType = PALCACHE_GRASS_SNOW; // Yes I know.. this is the only option here currently.
+						if (nType == PALCACHE_GRASS_SNOW)
+							return Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprGrassSnowFrame, pSpriteBuf, nFrmIdx);
+					}
+				}
 			}
+			return pSpriteBuf;
 		}
 		return pShapePtr->sprOffset.sprPtr;
 	}
@@ -1802,11 +1798,9 @@ static BYTE *Get_SpriteCache_Buffer(sprite_header_t *pShapePtr, __int16 nSpriteI
 
 static WORD Get_SpriteCache_Height(sprite_header_t *pShapePtr, __int16 nSpriteID) {
 	if (pShapePtr->wHeight > 1) {
-		if (bFrequentUpdates) {
-			BYTE *pSpriteBuf = Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprFrame, NULL, 0);
-			if (pSpriteBuf)
-				return spriteCache[nSpriteID].sprFrame[0].wHeight;
-		}
+		BYTE *pSpriteBuf = Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprFrame, NULL, 0);
+		if (pSpriteBuf)
+			return spriteCache[nSpriteID].sprFrame[0].wHeight;
 		return pShapePtr->wHeight;
 	}
 	return 0;
@@ -1814,11 +1808,9 @@ static WORD Get_SpriteCache_Height(sprite_header_t *pShapePtr, __int16 nSpriteID
 
 static WORD Get_SpriteCache_Width(sprite_header_t *pShapePtr, __int16 nSpriteID) {
 	if (pShapePtr->wHeight > 1) {
-		if (bFrequentUpdates) {
-			BYTE *pSpriteBuf = Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprFrame, NULL, 0);
-			if (pSpriteBuf)
-				return spriteCache[nSpriteID].sprFrame[0].wWidth;
-		}
+		BYTE *pSpriteBuf = Get_SpriteFrame_Buffer(spriteCache[nSpriteID].sprFrame, NULL, 0);
+		if (pSpriteBuf)
+			return spriteCache[nSpriteID].sprFrame[0].wWidth;
 		return pShapePtr->wWidth;
 	}
 	return 0;
@@ -1841,7 +1833,7 @@ static BYTE ProcessSeasonIndex(BYTE colIdx, BOOL bIgnore = FALSE) {
 static BYTE ProcessSpritePaletteIndex(__int16 nSpriteID, BYTE colIdx, WORD nRemHeight, int nPos) {
 	BYTE palIdx = colIdx;
 
-	if (bFrequentUpdates && bWeatherEffects && !bLoColor && bOnTheFlyPalIdx) {
+	if (bWeatherEffects && !bLoColor && bOnTheFlyPalIdx) {
 		// Accumulate snow or fading on trees
 		if (TreeSpritesCheck(nSpriteID)) {
 			if ((nPos % SEQ_MODULUS) == 0 || (nPos % SEQ_MODULUS) == 2 || (nPos % SEQ_MODULUS) == 3) {

--- a/hooks/hook_sc2k1996_miscellaneous.cpp
+++ b/hooks/hook_sc2k1996_miscellaneous.cpp
@@ -884,21 +884,22 @@ extern "C" void __stdcall Hook_SimcityApp_BuildSubFrames(void) {
 				}
 				if (pSCDoc && pSCDoc->pSimEngine) {
 					if (pThis->wSCAGameSpeedLOW != GAME_SPEED_PAUSED) {
-						if (bFrequentUpdates) {
-							BOOL bUpdateGameView = (wCityMode == GAME_MODE_DISASTER && !bOffCycle) ? FALSE : TRUE;
-							// Moved the title and view update calls out of the SimulationProcessTick()
-							// function so they always occur at the end to ensure everything is updated
-							// and to account for the new mode '3' for preserving the "placement preview"
-							// tile highlight during granular updates.
-							//
-							// When disaster mode is active we only want to instigate an update when
-							// 'OffCycle' in order to not have a negative effect on the disaster animations
-							// (Without this being done the animations are rather fast).
-							if (bUpdateGameView) {
-								Game_SimcityDoc_UpdateDocumentTitle(pSCDoc);
-								GameMain_Document_UpdateAllViews(pSCDoc, NULL, SCD_UPDATE_VIEW_UPDATE_WITHTILEINVERT, NULL);
-							}
-						}
+						BOOL bUpdateGameView = (wCityMode == GAME_MODE_DISASTER && !bOffCycle) ? FALSE : TRUE;
+						// Moved the title and view update calls out of the SimulationProcessTick()
+						// function so they always occur at the end to ensure everything is updated
+						// and to account for the new mode '3' for preserving the "placement preview"
+						// tile highlight during granular updates.
+						//
+						// When disaster mode is active we only want to instigate an update when
+						// 'OffCycle' is FALSE in order to not have a negative effect on the disaster
+						// animations (Without this being done the animations are rather fast).
+						//
+						// When "Frequent Updates" are disabled, only have it send a view update when
+						// bOffCycle is TRUE.
+						if (bFrequentUpdates && bUpdateGameView)
+							Game_SimcityDoc_UpdateDocumentTitle(pSCDoc);
+						if ((bFrequentUpdates && bUpdateGameView) || (!bFrequentUpdates && bOffCycle))
+							GameMain_Document_UpdateAllViews(pSCDoc, NULL, SCD_UPDATE_VIEW_UPDATE_WITHTILEINVERT, NULL);
 					}
 					GameMain_Document_UpdateAllViews(pSCDoc, NULL, SCD_UPDATE_VIEW_CHECKTILEINVERT, NULL);
 				}
@@ -1244,7 +1245,7 @@ extern "C" void __stdcall Hook_SimcityDoc_UpdateDocumentTitle() {
 		else
 			goto GETOUT;
 		Game_CurrencyString_TruncateAtSpace(pFundStr);
-		if (jsonSettingsCore[C_SC2KFIX][S_FIX_QOL][I_FIX_QOL_TITLECALEND].ToBool())
+		if (jsonSettingsCore[C_SC2KFIX][S_FIX_QOL][I_FIX_QOL_TITLECALEND].ToBool() && bFrequentUpdates)
 			GameMain_String_Format(&cStr, "%s %d %4d <%s> %s", pSCApp->dwSCApCStringLongMonths[iCityMonth].m_pchData, iCityDayMon, iCityYear, pszCityName.m_pchData, pFundStr->pStr);
 		else
 			GameMain_String_Format(&cStr, "%s %4d <%s> %s", pSCApp->dwSCApCStringShortMonths[iCityMonth].m_pchData, iCityYear, pszCityName.m_pchData, pFundStr->pStr);

--- a/modules/settings.cpp
+++ b/modules/settings.cpp
@@ -410,22 +410,20 @@ static BOOL CALLBACK SettingsDialogGameplayTabProc(HWND hwndDlg, UINT message, W
 			"The DOS and Mac versions of SimCity 2000 used a movable floating dialog to show the current tool, status line, and weather instead of a fixed bar at the bottom of the game window. "
 			"Enabling this setting will use the floating status dialog instead of the bottom status bar.");
 		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE),
-			"By default the title bar only displays the month and year. Enabling this setting will display the full in-game date instead.");
+			"By default the title bar only displays the month and year. Enabling this setting will display the full in-game date instead.\n\n"
+
+			"This setting does nothing unless the real-time renderer setting is also enabled.");
 		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS),
 			"Certain strings in the game have typos, grammatical issues, and/or ambiguous wording. This setting loads corrected strings in memory in place of the affected originals.");
 
 		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_REFRESH_RATE),
 			"SimCity 2000 was designed to spend more CPU time on simulation than on rendering by only updating the city's growth when the display moves or on the 24th day of the month. "
-			"Enabling this setting switches to a reimplemented renderer that refreshes the city display in real-time instead of batching display updates.\n\n"
-		
-			"This new renderer also allows for the implementation of weather and seasonal effects as well as a better and more future-proofed animation system.");
+			"Enabling this setting switches to a reimplemented renderer that refreshes the city display in real-time instead of batching display updates.");
 		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_WEATHER_EFFECTS),
 			"Enabling this setting causes the following weather and seasonal effects to be drawn:\n"
 			" - Trees will become less vibrant in autumn and winter.\n"
 			" - Trees and the ground will become dusted with snow during snowy weather, and covered in blizzards.\n"
-			" - Bodies of water will partially freeze during snowy weather and blizzards.\n\n"
-
-			"This setting does nothing unless the real-time renderer setting is also enabled.");
+			" - Bodies of water will partially freeze during snowy weather and blizzards.");
 		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_DARK_UNDGRND),
 			"When enabled the underground layer background will be dark.");
 		StoreTooltip(storedToolTips, hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SOUND_REPLACEMENTS),


### PR DESCRIPTION
This now disables the original cycling effect for sprites in both batch and frequent update modes.

Seasonal and weather effects are also now available in batch mode (though with the African Swallow speed they'll likely pass in the blink of an eye).