### PR TITLE
FluidSynth Adjustments

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -442,9 +442,10 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 			ConsoleLog(LOG_INFO, "UPD:  Update notifier thread started.\n");
 		}
 
-		// Create music thread
+		// Create music threads
 		CreateThread(NULL, 0, MusicThread, 0, 0, &dwMusicThreadID);
-		ConsoleLog(LOG_INFO, "MUS:  Music thread started.\n");
+		CreateThread(NULL, 0, FSMIDIThread, 0, 0, &dwFSMIDIThreadID);
+		ConsoleLog(LOG_INFO, "MUS:  Music threads started.\n");
 
 		CreateThread(NULL, 0, SDLSoundThread, 0, 0, &dwSDLSoundThreadID);
 		CreateThread(NULL, 0, SDLSongThread, 0, 0, &dwSDLSongThreadID);
@@ -582,7 +583,9 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 		if (dwSDLSoundThreadID)
 			PostThreadMessage(dwSDLSoundThreadID, WM_QUIT, NULL, NULL);
 
-		// Shut down the music thread
+		// Shut down the music threads
+		if (dwFSMIDIThreadID)
+			PostThreadMessage(dwFSMIDIThreadID, WM_QUIT, NULL, NULL);
 		if (dwMusicThreadID)
 			PostThreadMessage(dwMusicThreadID, WM_QUIT, NULL, NULL);
 

--- a/include/music.h
+++ b/include/music.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <fluidsynth.h>
-
 #define MUS_DEBUG_SONGS 1
 #define MUS_DEBUG_THREAD 2
 #define MUS_DEBUG_SEQUENCER 4

--- a/include/music.h
+++ b/include/music.h
@@ -30,7 +30,7 @@ enum {
 };
 
 void InstallMusicEngineHooks(void);
-const char *GetGameMusicSoundPath(int iSongID, BOOL bDoMP3);
+const char *GetGameMusicSoundPath(BOOL bDoMP3);
 DWORD WINAPI MusicThread(LPVOID lpParameter);
 void MusicShufflePlaylist(int iLastSongPlayed);
 

--- a/include/music.h
+++ b/include/music.h
@@ -3,9 +3,26 @@
 
 #pragma once
 
+#include <fluidsynth.h>
+
+#define MUS_DEBUG_SONGS 1
+#define MUS_DEBUG_THREAD 2
+#define MUS_DEBUG_SEQUENCER 4
+#define MUS_DEBUG_FLUIDSYNTH 8
+
+#define MUS_DEBUG DEBUG_FLAGS_NONE
+
+#ifdef DEBUGALL
+#undef MUS_DEBUG
+#define MUS_DEBUG DEBUG_FLAGS_EVERYTHING
+#endif
+
 #define WM_MUSIC_STOP	WM_APP+1
 #define WM_MUSIC_PLAY	WM_APP+2
 #define WM_MUSIC_RESET	WM_APP+3
+
+#define WM_FS_STOP	WM_APP+1
+#define WM_FS_PLAY	WM_APP+2
 
 enum {
 	MUSIC_ENGINE_NONE,
@@ -20,4 +37,8 @@ DWORD WINAPI MusicThread(LPVOID lpParameter);
 void MusicShufflePlaylist(int iLastSongPlayed);
 
 extern BOOL bUseMultithreadedMusic;
+extern bool bFluidSynthPlaying;
 extern DWORD dwMusicThreadID;
+extern DWORD dwFSMIDIThreadID;
+
+DWORD WINAPI FSMIDIThread(LPVOID lpParameter);

--- a/modules/fluidsynth_engine.cpp
+++ b/modules/fluidsynth_engine.cpp
@@ -263,7 +263,10 @@ static DWORD WINAPI FluidSynthSongThread(LPVOID lpParameter) {
 		ConsoleLog(LOG_DEBUG, "MUS: Starting new FluidSynth song 'join' monitoring thread.\n");
 
 	// Wait until the FluidSynth player thread exits
-	FS_fluid_player_join(pPlayer);
+	if (pPlayer)
+		FS_fluid_player_join(pPlayer);
+	else
+		ConsoleLog(LOG_DEBUG, "MUS: NULL pPlayer ???\n");
 
 	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
 		ConsoleLog(LOG_DEBUG, "MUS: Exiting FluidSynth song 'join' monitoring thread.\n");

--- a/modules/fluidsynth_engine.cpp
+++ b/modules/fluidsynth_engine.cpp
@@ -251,6 +251,7 @@ static void FluidSynthStopSong(fluid_audio_driver_t** pAudDriver, fluid_synth_t*
 }
 
 static DWORD WINAPI FluidSynthSongThread(LPVOID lpParameter) {
+	fluid_player_t *pPlayer = (fluid_player_t *)lpParameter;
 	if (bFSSongThreadActive) {
 		if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
 			ConsoleLog(LOG_DEBUG, "MUS: FluidSynth song 'join' monitoring thread already active.\n");
@@ -262,7 +263,7 @@ static DWORD WINAPI FluidSynthSongThread(LPVOID lpParameter) {
 		ConsoleLog(LOG_DEBUG, "MUS: Starting new FluidSynth song 'join' monitoring thread.\n");
 
 	// Wait until the FluidSynth player thread exits
-	FS_fluid_player_join(pFluidSynthPlayer);
+	FS_fluid_player_join(pPlayer);
 
 	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
 		ConsoleLog(LOG_DEBUG, "MUS: Exiting FluidSynth song 'join' monitoring thread.\n");
@@ -323,7 +324,7 @@ static bool FluidSynthPlaySong(fluid_audio_driver_t** pAudDriver, fluid_synth_t*
 	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
 		ConsoleLog(LOG_DEBUG, "MUS:  Started playback on pFluidSynthPlayer; joining player thread.\n");
 
-	hCurrentFSSongThread = CreateThread(NULL, 0, FluidSynthSongThread, NULL, 0, NULL);
+	hCurrentFSSongThread = CreateThread(NULL, 0, FluidSynthSongThread, *pPlayer, 0, NULL);
 
 	if (!hCurrentFSSongThread) {
 		FluidSynthStopSong(pAudDriver, pSynth, pPlayer);

--- a/modules/fluidsynth_engine.cpp
+++ b/modules/fluidsynth_engine.cpp
@@ -14,7 +14,7 @@
 #include <string>
 
 #include <sc2kfix.h>
-#include "music.h"
+#include <fluidsynth.h>
 #include "../resource.h"
 
 #define MAX_START 35

--- a/modules/fluidsynth_engine.cpp
+++ b/modules/fluidsynth_engine.cpp
@@ -346,11 +346,10 @@ DWORD WINAPI FSMIDIThread(LPVOID lpParameter) {
 
 	while (GetMessage(&msg, NULL, 0, 0)) {
 		if (msg.message == WM_FS_PLAY) {
-			int iPlayingSongID = (int)msg.wParam;
-			if (iPlayingSongID >= 10000 && iPlayingSongID <= 10018) {
+			if (msg.wParam >= 10000 && msg.wParam <= 10018) {
 				if (bFluidSynthPlaying)
 					goto next;
-				const char* szSongPath = GetGameMusicSoundPath(iPlayingSongID, FALSE);
+				const char* szSongPath = GetGameMusicSoundPath(FALSE);
 				if (szSongPath)
 					FluidSynthPlaySong(&pFluidSynthDriver, &pFluidSynthSynth, &pFluidSynthSettings, &pFluidSynthPlayer, szSongPath, true);
 			}

--- a/modules/fluidsynth_engine.cpp
+++ b/modules/fluidsynth_engine.cpp
@@ -1,0 +1,366 @@
+// sc2kfix modules/fluidsynth_engine.cpp: fluidsynth engine
+// (c) 2025-2026 sc2kfix project (https://sc2kfix.net) - released under the MIT license
+
+// Calls for FluidSynth have now been moved here.
+
+#undef UNICODE
+#include <windows.h>
+#include <psapi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <intrin.h>
+#include <list>
+#include <map>
+#include <string>
+
+#include <sc2kfix.h>
+#include "music.h"
+#include "../resource.h"
+
+#define MAX_START 35
+
+HMODULE hmodFluidSynth = NULL;
+DWORD dwFSMIDIThreadID = 0;
+bool bFluidSynthPlaying = false;
+
+static HANDLE hCurrentFSSongThread = 0;
+static BOOL bUseFluidSynth = FALSE;
+static fluid_settings_t* pFluidSynthSettings = NULL;
+static fluid_synth_t* pFluidSynthSynth = NULL;
+static fluid_player_t* pFluidSynthPlayer = NULL;
+static fluid_audio_driver_t* pFluidSynthDriver = NULL;
+static bool bFSSongThreadActive = false;
+
+// FluidSynth imports -- note that because we don't actually link against libfluidsynth-3.lib we
+// can't use the functions in the FluidSynth headers.
+
+fluid_settings_t* (*FS_new_fluid_settings)(void) = NULL;
+fluid_synth_t* (*FS_new_fluid_synth)(fluid_settings_t* settings) = NULL;
+fluid_player_t* (*FS_new_fluid_player)(fluid_synth_t* synth) = NULL;
+fluid_audio_driver_t* (*FS_new_fluid_audio_driver)(fluid_settings_t* settings, fluid_synth_t* synth) = NULL;
+fluid_midi_router_t* (*FS_new_fluid_midi_router)(fluid_settings_t* settings, handle_midi_event_func_t handler, void* event_handler_data) = NULL;
+int (*FS_fluid_synth_handle_midi_event)(void* data, fluid_midi_event_t* event) = NULL;
+int (*FS_fluid_is_soundfont)(const char* filename) = NULL;
+int (*FS_fluid_synth_sfload)(fluid_synth_t* synth, const char* filename, int reset_presets) = NULL;
+int (*FS_fluid_player_add)(fluid_player_t* player, const char* midifile) = NULL;
+int (*FS_fluid_player_play)(fluid_player_t* player) = NULL;
+int (*FS_fluid_player_stop)(fluid_player_t* player) = NULL;
+int (*FS_fluid_player_join)(fluid_player_t* player) = NULL;
+int (*FS_fluid_player_get_status)(fluid_player_t* player) = NULL;
+fluid_midi_router_rule_t* (*FS_new_fluid_midi_router_rule)(void) = NULL;
+int (*FS_fluid_midi_router_clear_rules)(fluid_midi_router_t* router) = NULL;
+void (*FS_fluid_midi_router_rule_set_chan)(fluid_midi_router_rule_t* rule, int min, int max, float mul, int add) = NULL;
+void (*FS_fluid_midi_router_rule_set_param1)(fluid_midi_router_rule_t* rule, int min, int max, float mul, int add) = NULL;
+void (*FS_fluid_midi_router_rule_set_param2)(fluid_midi_router_rule_t* rule, int min, int max, float mul, int add) = NULL;
+int (*FS_fluid_midi_router_add_rule)(fluid_midi_router_t* router, fluid_midi_router_rule_t* rule, int type) = NULL;
+void (*FS_delete_fluid_midi_router)(fluid_midi_router_t* router) = NULL;
+void (*FS_delete_fluid_audio_driver)(fluid_audio_driver_t* driver) = NULL;
+void (*FS_delete_fluid_player)(fluid_player_t* player) = NULL;
+void (*FS_delete_fluid_synth)(fluid_synth_t* synth) = NULL;
+void (*FS_delete_fluid_settings)(fluid_settings_t* settings) = NULL;
+int (*FS_fluid_midi_event_get_type)(fluid_midi_event_t* event) = NULL;
+int (*FS_fluid_midi_event_get_channel)(fluid_midi_event_t* event) = NULL;
+int (*FS_fluid_player_set_playback_callback)(fluid_player_t* player, handle_midi_event_func_t handler, void* handler_data) = NULL;
+int (*FS_fluid_synth_all_sounds_off)(fluid_synth_t* synth, int chan) = NULL;
+fluid_log_function_t (*FS_fluid_set_log_function)(int level, fluid_log_function_t fun, void* data);
+int (*FS_fluid_settings_setint)(fluid_settings_t* settings, const char* name, int val);
+int (*FS_fluid_settings_setnum)(fluid_settings_t* settings, const char* name, double val);
+
+static int MusicFluidSynthMidiEventHandler(void* data, fluid_midi_event_t* event) {
+	fluid_synth_t* synth = (fluid_synth_t*)data;
+	int type = FS_fluid_midi_event_get_type(event);
+	int channel = FS_fluid_midi_event_get_channel(event);
+
+	// Ignore all notes on channel 15; pass other notes. This works around the fact that the MIDI
+	// files have the drum track duplicated on channel 15, which FluidSynth defaults to being a
+	// full volume Acoustic Grand Piano track (plink plonk plink plonk i'm a drum machine!)
+	if (type == 0x90 && channel == 15)
+		return FLUID_OK;
+	return FS_fluid_synth_handle_midi_event(data, event);
+}
+
+static void MusicFluidSynthLoggerError(int level, const char* message, void* data) {
+	// Ignore the error we get if we're loading the default Windows GM "soundfont"
+	if (message && !strcmp(message, "Not a SoundFont file") && !_stricmp(GetFileBaseName(jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SOUNDFONT].ToString().c_str()), "gm.dls"))
+		return;
+
+	ConsoleLog(LOG_ERROR, "MUS:  FluidSynth: %s\n", message);
+}
+
+static void MusicFluidSynthLoggerWarning(int level, const char* message, void* data) {
+	if (message && (!strncmp(message, "SDL", 3) || !strncmp(message, "Ignoring unknown top-level DLS chunk", 36)))
+		return;
+	ConsoleLog(LOG_WARNING, "MUS:  FluidSynth: %s\n", message);
+}
+
+bool MusicLoadFluidSynth(void) {
+	if (mus_debug & MUS_DEBUG_FLUIDSYNTH)
+		ConsoleLog(LOG_DEBUG, "MUS:  FluidSynth enabled, probing for valid FluidSynth library.\n");
+
+	// Disable FluidSynth support if the library doesn't exist.
+	if (!FileExists("libfluidsynth-3.dll")) {
+		if (mus_debug & MUS_DEBUG_FLUIDSYNTH)
+			ConsoleLog(LOG_DEBUG, "MUS:  FluidSynth library doesn't exist; disabling support.\n");
+		hmodFluidSynth = FALSE;
+		return FALSE;
+	}
+
+	// Attempt to load the FluidSynth library.
+	hmodFluidSynth = LoadLibrary("libfluidsynth-3.dll");
+	if (!hmodFluidSynth) {
+		ConsoleLog(LOG_ERROR, "MUS:  FluidSynth could not be loaded (error 0x%08X). Disabling FluidSynth.\n", GetLastError());
+		return FALSE;
+	}
+
+	if (mus_debug & MUS_DEBUG_FLUIDSYNTH)
+		ConsoleLog(LOG_DEBUG, "MUS:  FluidSynth loaded at address 0x%08X.\n", hmodFluidSynth);
+
+	// Signal our intent to use FluidSynth and start locating function addresses.
+	bUseFluidSynth = TRUE;
+	if ((FS_new_fluid_settings = (decltype(FS_new_fluid_settings))GetProcAddress(hmodFluidSynth, "new_fluid_settings")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_new_fluid_synth = (decltype(FS_new_fluid_synth))GetProcAddress(hmodFluidSynth, "new_fluid_synth")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_new_fluid_player = (decltype(FS_new_fluid_player))GetProcAddress(hmodFluidSynth, "new_fluid_player")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_new_fluid_audio_driver = (decltype(FS_new_fluid_audio_driver))GetProcAddress(hmodFluidSynth, "new_fluid_audio_driver")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_new_fluid_midi_router = (decltype(FS_new_fluid_midi_router))GetProcAddress(hmodFluidSynth, "new_fluid_midi_router")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_synth_handle_midi_event = (decltype(FS_fluid_synth_handle_midi_event))GetProcAddress(hmodFluidSynth, "fluid_synth_handle_midi_event")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_is_soundfont = (decltype(FS_fluid_is_soundfont))GetProcAddress(hmodFluidSynth, "fluid_is_soundfont")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_synth_sfload = (decltype(FS_fluid_synth_sfload))GetProcAddress(hmodFluidSynth, "fluid_synth_sfload")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_player_add = (decltype(FS_fluid_player_add))GetProcAddress(hmodFluidSynth, "fluid_player_add")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_player_play = (decltype(FS_fluid_player_play))GetProcAddress(hmodFluidSynth, "fluid_player_play")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_player_stop = (decltype(FS_fluid_player_stop))GetProcAddress(hmodFluidSynth, "fluid_player_stop")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_player_join = (decltype(FS_fluid_player_join))GetProcAddress(hmodFluidSynth, "fluid_player_join")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_player_get_status = (decltype(FS_fluid_player_get_status))GetProcAddress(hmodFluidSynth, "fluid_player_get_status")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_new_fluid_midi_router_rule = (decltype(FS_new_fluid_midi_router_rule))GetProcAddress(hmodFluidSynth, "new_fluid_midi_router_rule")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_midi_router_clear_rules = (decltype(FS_fluid_midi_router_clear_rules))GetProcAddress(hmodFluidSynth, "fluid_midi_router_clear_rules")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_midi_router_rule_set_chan = (decltype(FS_fluid_midi_router_rule_set_chan))GetProcAddress(hmodFluidSynth, "fluid_midi_router_rule_set_chan")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_midi_router_rule_set_param1 = (decltype(FS_fluid_midi_router_rule_set_param1))GetProcAddress(hmodFluidSynth, "fluid_midi_router_rule_set_param1")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_midi_router_rule_set_param2 = (decltype(FS_fluid_midi_router_rule_set_param2))GetProcAddress(hmodFluidSynth, "fluid_midi_router_rule_set_param2")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_midi_router_add_rule = (decltype(FS_fluid_midi_router_add_rule))GetProcAddress(hmodFluidSynth, "fluid_midi_router_add_rule")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_delete_fluid_midi_router = (decltype(FS_delete_fluid_midi_router))GetProcAddress(hmodFluidSynth, "delete_fluid_midi_router")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_delete_fluid_audio_driver = (decltype(FS_delete_fluid_audio_driver))GetProcAddress(hmodFluidSynth, "delete_fluid_audio_driver")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_delete_fluid_player = (decltype(FS_delete_fluid_player))GetProcAddress(hmodFluidSynth, "delete_fluid_player")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_delete_fluid_synth = (decltype(FS_delete_fluid_synth))GetProcAddress(hmodFluidSynth, "delete_fluid_synth")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_delete_fluid_settings = (decltype(FS_delete_fluid_settings))GetProcAddress(hmodFluidSynth, "delete_fluid_settings")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_midi_event_get_type = (decltype(FS_fluid_midi_event_get_type))GetProcAddress(hmodFluidSynth, "fluid_midi_event_get_type")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_midi_event_get_channel = (decltype(FS_fluid_midi_event_get_channel))GetProcAddress(hmodFluidSynth, "fluid_midi_event_get_channel")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_player_set_playback_callback = (decltype(FS_fluid_player_set_playback_callback))GetProcAddress(hmodFluidSynth, "fluid_player_set_playback_callback")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_synth_all_sounds_off = (decltype(FS_fluid_synth_all_sounds_off))GetProcAddress(hmodFluidSynth, "fluid_synth_all_sounds_off")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_set_log_function = (decltype(FS_fluid_set_log_function))GetProcAddress(hmodFluidSynth, "fluid_set_log_function")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_settings_setint = (decltype(FS_fluid_settings_setint))GetProcAddress(hmodFluidSynth, "fluid_settings_setint")) == NULL)
+		bUseFluidSynth = FALSE;
+	if ((FS_fluid_settings_setnum = (decltype(FS_fluid_settings_setnum))GetProcAddress(hmodFluidSynth, "fluid_settings_setnum")) == NULL)
+		bUseFluidSynth = FALSE;
+
+	// If any of our loads failed, release the FluidSynth library, throw an error, and fall 
+	// back to using MCI.
+	if (!bUseFluidSynth) {
+		ConsoleLog(LOG_ERROR, "MUS:  One or more FluidSynth functions could not be loaded. Disabling FluidSynth.\n");
+		FreeLibrary(hmodFluidSynth);
+		hmodFluidSynth = NULL;
+		return FALSE;
+	}
+
+	if (mus_debug & MUS_DEBUG_FLUIDSYNTH)
+		ConsoleLog(LOG_DEBUG, "MUS:  Loaded FluidSynth function pointers.\n");
+
+	// Set FluidSynth's log functions
+	FS_fluid_set_log_function(FLUID_PANIC, MusicFluidSynthLoggerError, NULL);
+	FS_fluid_set_log_function(FLUID_ERR, MusicFluidSynthLoggerError, NULL);
+	FS_fluid_set_log_function(FLUID_WARN, MusicFluidSynthLoggerWarning, NULL);
+	FS_fluid_set_log_function(FLUID_INFO, NULL, NULL);
+	FS_fluid_set_log_function(FLUID_DBG, NULL, NULL);
+
+	// Create initial FluidSynth data
+	pFluidSynthSettings = FS_new_fluid_settings();
+	pFluidSynthSynth = FS_new_fluid_synth(pFluidSynthSettings);
+
+	return TRUE;
+}
+
+static void FluidSynthStopSong(fluid_audio_driver_t** pAudDriver, fluid_synth_t** pSynth, fluid_player_t** pPlayer) {
+	int i;
+	
+	if (!pAudDriver && !pSynth && !pPlayer)
+		return;
+
+	// Stop and delete the existing player-driver combo if it exists
+	if (*pPlayer) {
+		FS_fluid_player_stop(*pPlayer);
+
+		if (bFSSongThreadActive || hCurrentFSSongThread) {
+			if (hCurrentFSSongThread) {
+				if (bFSSongThreadActive) {
+					for (i=MAX_START; i>0; i--)
+					{
+						if (!bFSSongThreadActive) break;
+						Sleep(100);
+					}
+				}
+
+				DWORD dwThreadID = GetThreadId(hCurrentFSSongThread);
+				if (dwThreadID) {
+					if (!TerminateThread(hCurrentFSSongThread, EXIT_SUCCESS))
+						ConsoleLog(LOG_DEBUG, "FluidSynthStopSong(): Hmmm... 0x%06X\n", GetLastError());
+					else {
+						hCurrentFSSongThread = 0;
+						bFSSongThreadActive = false;
+					}
+				}
+			}
+		}
+
+		for (i = 0; i < 16; i++)
+			FS_fluid_synth_all_sounds_off(*pSynth, i);
+		FS_delete_fluid_audio_driver(*pAudDriver);
+		FS_delete_fluid_player(*pPlayer);
+
+		*pAudDriver = 0;
+		*pPlayer = 0;
+	}
+
+	bFluidSynthPlaying = false;
+}
+
+static DWORD WINAPI FluidSynthSongThread(LPVOID lpParameter) {
+	if (bFSSongThreadActive) {
+		if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
+			ConsoleLog(LOG_DEBUG, "MUS: FluidSynth song 'join' monitoring thread already active.\n");
+		return EXIT_SUCCESS;
+	}
+	bFSSongThreadActive = true;
+	
+	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
+		ConsoleLog(LOG_DEBUG, "MUS: Starting new FluidSynth song 'join' monitoring thread.\n");
+
+	// Wait until the FluidSynth player thread exits
+	FS_fluid_player_join(pFluidSynthPlayer);
+
+	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
+		ConsoleLog(LOG_DEBUG, "MUS: Exiting FluidSynth song 'join' monitoring thread.\n");
+
+	bFSSongThreadActive = false;
+	bFluidSynthPlaying = false;
+
+	// In the old watchdog thread there was a sleep call at
+	// the end that was present to avoid any reverb-effect
+	// overlap. It is being kept here in a commented-out state
+	// just in case it is indeed needed:
+	// Sleep(250);
+	return EXIT_SUCCESS;
+}
+
+static bool FluidSynthPlaySong(fluid_audio_driver_t** pAudDriver, fluid_synth_t** pSynth, fluid_settings_t** pSettings, fluid_player_t** pPlayer, const char *szSongPath, bool bOverride) {
+	if (!pPlayer)
+		return false;
+
+	if (!bOverride && bFluidSynthPlaying)
+		return false;
+
+	FluidSynthStopSong(pAudDriver, pSynth, pPlayer);
+	
+	if (bFSSongThreadActive) {
+		// Display this all the time; if it "does" crop up
+		// then it "should" only be if the thread fails
+		// to terminate, in which case another notice should
+		// also be displayed - if not then we cross that bridge.
+		if (hCurrentFSSongThread)
+			ConsoleLog(LOG_DEBUG, "MUS: ??? - FluidSynth song 'join' monitoring thread is still active: 0x%06X\n", hCurrentFSSongThread);
+		else
+			bFSSongThreadActive = false;
+	}
+
+	// Spin up a new player-driver combo
+	*pPlayer = FS_new_fluid_player(*pSynth);
+	if (FS_fluid_is_soundfont(jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SOUNDFONT].ToString().c_str()))
+		FS_fluid_synth_sfload(*pSynth, jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SOUNDFONT].ToString().c_str(), 1);
+	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
+		ConsoleLog(LOG_DEBUG, "MUS:  Loaded soundfont \"%s\" into new pFluidSynthPlayer.\n", jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SOUNDFONT].ToString().c_str());
+
+	FS_fluid_player_set_playback_callback(*pPlayer, MusicFluidSynthMidiEventHandler, *pSynth);
+	FS_fluid_player_add(*pPlayer, szSongPath);
+	*pAudDriver = FS_new_fluid_audio_driver(pFluidSynthSettings, *pSynth);
+	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
+		ConsoleLog(LOG_DEBUG, "MUS:  Loaded MIDI file \"%s\" into pFluidSynthPlayer.\n", szSongPath);
+
+	// Disable chorus and set reverb and gain to the default level used by Roland synthesizers
+	// Also update the music volume here
+	FS_fluid_settings_setint(*pSettings, "synth.chorus.active", 0);
+	FS_fluid_settings_setnum(*pSettings, "synth.reverb.level", 0.3);
+	FS_fluid_settings_setnum(*pSettings, "synth.gain", 0.5 * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICVOLUME].ToFloat() * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MASTERVOLUME].ToFloat());
+
+	// Play track
+	FS_fluid_player_play(*pPlayer);
+	bFluidSynthPlaying = true;
+	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
+		ConsoleLog(LOG_DEBUG, "MUS:  Started playback on pFluidSynthPlayer; joining player thread.\n");
+
+	hCurrentFSSongThread = CreateThread(NULL, 0, FluidSynthSongThread, NULL, 0, NULL);
+
+	if (!hCurrentFSSongThread) {
+		FluidSynthStopSong(pAudDriver, pSynth, pPlayer);
+		return false;
+	}
+
+	SetThreadPriority(hCurrentFSSongThread, THREAD_PRIORITY_TIME_CRITICAL);
+	return true;
+}
+
+DWORD WINAPI FSMIDIThread(LPVOID lpParameter) {
+	MSG msg;
+
+	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
+		ConsoleLog(LOG_DEBUG, "MUS:  Starting new FluidSynth MIDI thread.\n");
+
+	while (GetMessage(&msg, NULL, 0, 0)) {
+		if (msg.message == WM_FS_PLAY) {
+			int iPlayingSongID = (int)msg.wParam;
+			if (iPlayingSongID >= 10000 && iPlayingSongID <= 10018) {
+				if (bFluidSynthPlaying)
+					goto next;
+				const char* szSongPath = GetGameMusicSoundPath(iPlayingSongID, FALSE);
+				if (szSongPath)
+					FluidSynthPlaySong(&pFluidSynthDriver, &pFluidSynthSynth, &pFluidSynthSettings, &pFluidSynthPlayer, szSongPath, true);
+			}
+		}
+		else if (msg.message == WM_FS_STOP)
+			FluidSynthStopSong(&pFluidSynthDriver, &pFluidSynthSynth, &pFluidSynthPlayer);
+		else if (msg.message == WM_QUIT)
+			break;
+	next:
+		DispatchMessage(&msg);
+	}
+
+	FluidSynthStopSong(&pFluidSynthDriver, &pFluidSynthSynth, &pFluidSynthPlayer);
+	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
+		ConsoleLog(LOG_INFO, "MUS:  Shutting down FluidSynth MIDI thread.\n");
+	return EXIT_SUCCESS;
+}

--- a/modules/music.cpp
+++ b/modules/music.cpp
@@ -28,6 +28,10 @@ const char *GetGameSoundPath() {
 	return szSoundPath;
 }
 
+static void SetCurrentActiveSongID(int iSongID) {
+	iPlayingSongID = iSongID;
+}
+
 int GetCurrentActiveSongID() {
 	return iPlayingSongID;
 }
@@ -130,12 +134,14 @@ static BOOL ValidateFilename(const char *pName, const char *pExt) {
 	return FALSE;
 }
 
-const char *GetGameMusicSoundPath(int iSongID, BOOL bDoMP3) {
+const char *GetGameMusicSoundPath(BOOL bDoMP3) {
 	const char *pExt;
 	static std::string strSongPath;
 	BOOL bUseAliasedSong;
 	int iAliasIdx;
+	int iSongID;
 
+	iSongID = GetCurrentActiveSongID();
 	// TODO: clean up alias index stuff
 	pExt = (bDoMP3) ? ".mp3" : ".mid";
 	strSongPath = szSoundPath;
@@ -204,7 +210,7 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 				goto next;
 
 			dwMCIError = mciSendCommand(mciDevice, MCI_CLOSE, MCI_WAIT, NULL);
-			iPlayingSongID = 0;
+			SetCurrentActiveSongID(0);
 
 			if (mus_debug & MUS_DEBUG_THREAD)
 				ConsoleLog(LOG_DEBUG, "MUS:  Sent MCI_CLOSE to mciDevice 0x%08X.\n", mciDevice);
@@ -231,41 +237,33 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 			// If we're using FluidSynth, set up a watchdog thread that runs the FluidSynth engine
 			// and waits for it to exit
 			if (pSCApp->dwSCAGameMusic) {
-				if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() == "fluidsynth") {
-					if (hmodFluidSynth) {
-						if (msg.wParam >= 10000 && msg.wParam <= 10018) {
-							iPlayingSongID = msg.wParam;
-							const char* szSongPath = GetGameMusicSoundPath(iPlayingSongID, FALSE);
-
+				if (msg.wParam >= 10000 && msg.wParam <= 10018) {
+					SetCurrentActiveSongID(msg.wParam);
+					if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() == "fluidsynth") {
+						if (hmodFluidSynth) {
+							const char* szSongPath = GetGameMusicSoundPath(FALSE);
 							if (szSongPath)
-								PostThreadMessageA(dwFSMIDIThreadID, WM_FS_PLAY, iPlayingSongID, 0);
+								PostThreadMessageA(dwFSMIDIThreadID, WM_FS_PLAY, msg.wParam, 0);
 							goto next;
 						}
+						else
+							ConsoleLog(LOG_ERROR, "MUS: FluidSynth not loaded; failing back to MIDI sequencer.\n");
 					}
-					else
-						ConsoleLog(LOG_ERROR, "MUS: FluidSynth not loaded; failing back to MIDI sequencer.\n");
-				}
 
-				// Attempt MP3 playback via SDL3 if we've got it selected
-				if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() == "mp3") {
-					if (msg.wParam >= 10000 && msg.wParam <= 10018) {
-						iPlayingSongID = msg.wParam;
-						const char* szSongPath = GetGameMusicSoundPath(iPlayingSongID, TRUE);
-
+					// Attempt MP3 playback via SDL3 if we've got it selected
+					if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() == "mp3") {
+						const char* szSongPath = GetGameMusicSoundPath(TRUE);
 						if (szSongPath) {
-							PostThreadMessageA(dwSDLSongThreadID, WM_SDL_PLAY, iPlayingSongID, 0);
+							PostThreadMessageA(dwSDLSongThreadID, WM_SDL_PLAY, msg.wParam, 0);
 							goto next;
-						} else
+						}
+						else
 							ConsoleLog(LOG_ERROR, "MUS:  Could not find music file %s; failing back to MIDI sequencer.\n", szSongPath);
 					}
-				}
 
-				// Failing all of the above, use MCI to handle MIDI playback
-				if (!mciDevice) {
-					if (msg.wParam >= 10000 && msg.wParam <= 10018) {
-						iPlayingSongID = msg.wParam;
-						const char* szSongPath = GetGameMusicSoundPath(iPlayingSongID, FALSE);
-						
+					// Failing all of the above, use MCI to handle MIDI playback
+					if (!mciDevice) {
+						const char* szSongPath = GetGameMusicSoundPath(FALSE);
 						if (!szSongPath)
 							goto next;
 
@@ -275,7 +273,7 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 							char szErrorBuf[MAXERRORLENGTH];
 							mciGetErrorString(dwMCIError, szErrorBuf, MAXERRORLENGTH);
 							ConsoleLog(LOG_ERROR, "MUS:  MCI_OPEN failed, 0x%08X (%s)\n", dwMCIError, szErrorBuf);
-							iPlayingSongID = 0;
+							SetCurrentActiveSongID(0);
 							goto next;
 						}
 
@@ -283,7 +281,7 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 							ConsoleLog(LOG_DEBUG, "MUS:  Received mciDevice 0x%08X from MCI_OPEN.\n", mciDevice);
 
 						mciDevice = mciOpenParms.wDeviceID;
-						MCI_PLAY_PARMS mciPlayParms = { (DWORD_PTR)GameGetRootWindowHandle(), NULL, NULL};
+						MCI_PLAY_PARMS mciPlayParms = { (DWORD_PTR)GameGetRootWindowHandle(), NULL, NULL };
 						dwMCIError = mciSendCommand(mciDevice, MCI_PLAY, MCI_NOTIFY, (DWORD_PTR)&mciPlayParms);
 						// SC2K sometimes tries to run over its own sequencer device. We ignore the
 						// error that causes (0x151, MCIERR_SEQ_PORT_INUSE) just like the game itself does.
@@ -291,17 +289,15 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 							char szErrorBuf[MAXERRORLENGTH];
 							mciGetErrorString(dwMCIError, szErrorBuf, MAXERRORLENGTH);
 							ConsoleLog(LOG_ERROR, "MUS:  MCI_PLAY failed, 0x%08X (%s)\n", dwMCIError, szErrorBuf);
-							iPlayingSongID = 0;
+							SetCurrentActiveSongID(0);
 							goto next;
 						}
-
-
 					}
-				}
-				else {
-					if (mus_debug & MUS_DEBUG_THREAD && msg.lParam != 1)
-						ConsoleLog(LOG_DEBUG, "MUS:  WM_MUSIC_PLAY message received but MCI is still active; discarding message.\n");
-					goto next;
+					else {
+						if (mus_debug & MUS_DEBUG_THREAD && msg.lParam != 1)
+							ConsoleLog(LOG_DEBUG, "MUS:  WM_MUSIC_PLAY message received but MCI is still active; discarding message.\n");
+						goto next;
+					}
 				}
 			}
 		}
@@ -331,8 +327,9 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 			// Only restart if the engine is not set to MUSIC_ENGINE_NONE
 			if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() != "none") {
 				// Restart the active song if there is one
-				if (iPlayingSongID)
-					DoMusicPlay(iPlayingSongID, FALSE);
+				int iSongID = GetCurrentActiveSongID();
+				if (iSongID)
+					DoMusicPlay(iSongID, FALSE);
 			}
 
 			goto next;

--- a/modules/music.cpp
+++ b/modules/music.cpp
@@ -11,74 +11,18 @@
 #include <string>
 
 #include <sc2kfix.h>
-#include <fluidsynth.h>
-
-#define MUS_DEBUG_SONGS 1
-#define MUS_DEBUG_THREAD 2
-#define MUS_DEBUG_SEQUENCER 4
-#define MUS_DEBUG_FLUIDSYNTH 8
-
-#define MUS_DEBUG DEBUG_FLAGS_NONE
-
-#ifdef DEBUGALL
-#undef MUS_DEBUG
-#define MUS_DEBUG DEBUG_FLAGS_EVERYTHING
-#endif
 
 UINT mus_debug = MUS_DEBUG;
 
 static DWORD dwDummy;
 
+static int iPlayingSongID = 0;
 std::vector<int> vectorRandomSongIDs = { 10001, 10004, 10008, 10012, 10018, 10003, 10007, 10011, 10013, 10017 };
 int iCurrentSong = 0;
-int iPlayingSongID = 0;
 DWORD dwMusicThreadID = 0;
 MCIDEVICEID mciDevice = NULL;
 BOOL bMultithreadedMusicEnabled = FALSE;
-BOOL bUseFluidSynth = FALSE;
 bool bMusicForceIntroSongOnce = true;
-
-HMODULE hmodFluidSynth = NULL;
-fluid_settings_t* pFluidSynthSettings = NULL;
-fluid_synth_t* pFluidSynthSynth = NULL;
-fluid_player_t* pFluidSynthPlayer = NULL;
-fluid_audio_driver_t* pFluidSynthDriver = NULL;
-BOOL bFluidSynthPlaying = FALSE;
-
-// FluidSynth imports -- note that because we don't actually link against libfluidsynth-3.lib we
-// can't use the functions in the FluidSynth headers.
-
-fluid_settings_t* (*FS_new_fluid_settings)(void) = NULL;
-fluid_synth_t* (*FS_new_fluid_synth)(fluid_settings_t* settings) = NULL;
-fluid_player_t* (*FS_new_fluid_player)(fluid_synth_t* synth) = NULL;
-fluid_audio_driver_t* (*FS_new_fluid_audio_driver)(fluid_settings_t* settings, fluid_synth_t* synth) = NULL;
-fluid_midi_router_t* (*FS_new_fluid_midi_router)(fluid_settings_t* settings, handle_midi_event_func_t handler, void* event_handler_data) = NULL;
-int (*FS_fluid_synth_handle_midi_event)(void* data, fluid_midi_event_t* event) = NULL;
-int (*FS_fluid_is_soundfont)(const char* filename) = NULL;
-int (*FS_fluid_synth_sfload)(fluid_synth_t* synth, const char* filename, int reset_presets) = NULL;
-int (*FS_fluid_player_add)(fluid_player_t* player, const char* midifile) = NULL;
-int (*FS_fluid_player_play)(fluid_player_t* player) = NULL;
-int (*FS_fluid_player_stop)(fluid_player_t* player) = NULL;
-int (*FS_fluid_player_join)(fluid_player_t* player) = NULL;
-int (*FS_fluid_player_get_status)(fluid_player_t* player) = NULL;
-fluid_midi_router_rule_t* (*FS_new_fluid_midi_router_rule)(void) = NULL;
-int (*FS_fluid_midi_router_clear_rules)(fluid_midi_router_t* router) = NULL;
-void (*FS_fluid_midi_router_rule_set_chan)(fluid_midi_router_rule_t* rule, int min, int max, float mul, int add) = NULL;
-void (*FS_fluid_midi_router_rule_set_param1)(fluid_midi_router_rule_t* rule, int min, int max, float mul, int add) = NULL;
-void (*FS_fluid_midi_router_rule_set_param2)(fluid_midi_router_rule_t* rule, int min, int max, float mul, int add) = NULL;
-int (*FS_fluid_midi_router_add_rule)(fluid_midi_router_t* router, fluid_midi_router_rule_t* rule, int type) = NULL;
-void (*FS_delete_fluid_midi_router)(fluid_midi_router_t* router) = NULL;
-void (*FS_delete_fluid_audio_driver)(fluid_audio_driver_t* driver) = NULL;
-void (*FS_delete_fluid_player)(fluid_player_t* player) = NULL;
-void (*FS_delete_fluid_synth)(fluid_synth_t* synth) = NULL;
-void (*FS_delete_fluid_settings)(fluid_settings_t* settings) = NULL;
-int (*FS_fluid_midi_event_get_type)(fluid_midi_event_t* event) = NULL;
-int (*FS_fluid_midi_event_get_channel)(fluid_midi_event_t* event) = NULL;
-int (*FS_fluid_player_set_playback_callback)(fluid_player_t* player, handle_midi_event_func_t handler, void* handler_data) = NULL;
-int (*FS_fluid_synth_all_sounds_off)(fluid_synth_t* synth, int chan) = NULL;
-fluid_log_function_t (*FS_fluid_set_log_function)(int level, fluid_log_function_t fun, void* data);
-int (*FS_fluid_settings_setint)(fluid_settings_t* settings, const char* name, int val);
-int (*FS_fluid_settings_setnum)(fluid_settings_t* settings, const char* name, double val);
 
 const char *GetGameSoundPath() {
 	return szSoundPath;
@@ -133,204 +77,6 @@ void WINAPI MusicMCINotifyCallback(WPARAM wFlags, LPARAM lDevID) {
 		if (mus_debug & MUS_DEBUG_THREAD)
 			ConsoleLog(LOG_DEBUG, "MUS:  MusicMCINotifyCallback posted WM_MUSIC_STOP. (%u, %u)\n", wFlags, lDevID);
 	}
-}
-
-int MusicFluidSynthMidiEventHandler(void* data, fluid_midi_event_t* event) {
-	fluid_synth_t* synth = (fluid_synth_t*)data;
-	int type = FS_fluid_midi_event_get_type(event);
-	int channel = FS_fluid_midi_event_get_channel(event);
-
-	// Ignore all notes on channel 15; pass other notes. This works around the fact that the MIDI
-	// files have the drum track duplicated on channel 15, which FluidSynth defaults to being a
-	// full volume Acoustic Grand Piano track (plink plonk plink plonk i'm a drum machine!)
-	if (type == 0x90 && channel == 15)
-		return FLUID_OK;
-	return FS_fluid_synth_handle_midi_event(data, event);
-}
-
-void MusicFluidSynthLoggerError(int level, const char* message, void* data) {
-	// Ignore the error we get if we're loading the default Windows GM "soundfont"
-	if (message && !strcmp(message, "Not a SoundFont file") && !_stricmp(GetFileBaseName(jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SOUNDFONT].ToString().c_str()), "gm.dls"))
-		return;
-
-	ConsoleLog(LOG_ERROR, "MUS:  FluidSynth: %s\n", message);
-}
-
-void MusicFluidSynthLoggerWarning(int level, const char* message, void* data) {
-	if (message && (!strncmp(message, "SDL", 3) || !strncmp(message, "Ignoring unknown top-level DLS chunk", 36)))
-		return;
-	ConsoleLog(LOG_WARNING, "MUS:  FluidSynth: %s\n", message);
-}
-
-bool MusicLoadFluidSynth(void) {
-	if (mus_debug & MUS_DEBUG_FLUIDSYNTH)
-		ConsoleLog(LOG_DEBUG, "MUS:  FluidSynth enabled, probing for valid FluidSynth library.\n");
-
-	// Disable FluidSynth support if the library doesn't exist.
-	if (!FileExists("libfluidsynth-3.dll")) {
-		if (mus_debug & MUS_DEBUG_FLUIDSYNTH)
-			ConsoleLog(LOG_DEBUG, "MUS:  FluidSynth library doesn't exist; disabling support.\n");
-		hmodFluidSynth = FALSE;
-		return FALSE;
-	}
-
-	// Attempt to load the FluidSynth library.
-	hmodFluidSynth = LoadLibrary("libfluidsynth-3.dll");
-	if (!hmodFluidSynth) {
-		ConsoleLog(LOG_ERROR, "MUS:  FluidSynth could not be loaded (error 0x%08X). Disabling FluidSynth.\n", GetLastError());
-		return FALSE;
-	}
-
-	if (mus_debug & MUS_DEBUG_FLUIDSYNTH)
-		ConsoleLog(LOG_DEBUG, "MUS:  FluidSynth loaded at address 0x%08X.\n", hmodFluidSynth);
-
-	// Signal our intent to use FluidSynth and start locating function addresses.
-	bUseFluidSynth = TRUE;
-	if ((FS_new_fluid_settings = (decltype(FS_new_fluid_settings))GetProcAddress(hmodFluidSynth, "new_fluid_settings")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_new_fluid_synth = (decltype(FS_new_fluid_synth))GetProcAddress(hmodFluidSynth, "new_fluid_synth")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_new_fluid_player = (decltype(FS_new_fluid_player))GetProcAddress(hmodFluidSynth, "new_fluid_player")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_new_fluid_audio_driver = (decltype(FS_new_fluid_audio_driver))GetProcAddress(hmodFluidSynth, "new_fluid_audio_driver")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_new_fluid_midi_router = (decltype(FS_new_fluid_midi_router))GetProcAddress(hmodFluidSynth, "new_fluid_midi_router")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_synth_handle_midi_event = (decltype(FS_fluid_synth_handle_midi_event))GetProcAddress(hmodFluidSynth, "fluid_synth_handle_midi_event")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_is_soundfont = (decltype(FS_fluid_is_soundfont))GetProcAddress(hmodFluidSynth, "fluid_is_soundfont")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_synth_sfload = (decltype(FS_fluid_synth_sfload))GetProcAddress(hmodFluidSynth, "fluid_synth_sfload")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_player_add = (decltype(FS_fluid_player_add))GetProcAddress(hmodFluidSynth, "fluid_player_add")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_player_play = (decltype(FS_fluid_player_play))GetProcAddress(hmodFluidSynth, "fluid_player_play")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_player_stop = (decltype(FS_fluid_player_stop))GetProcAddress(hmodFluidSynth, "fluid_player_stop")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_player_join = (decltype(FS_fluid_player_join))GetProcAddress(hmodFluidSynth, "fluid_player_join")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_player_get_status = (decltype(FS_fluid_player_get_status))GetProcAddress(hmodFluidSynth, "fluid_player_get_status")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_new_fluid_midi_router_rule = (decltype(FS_new_fluid_midi_router_rule))GetProcAddress(hmodFluidSynth, "new_fluid_midi_router_rule")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_midi_router_clear_rules = (decltype(FS_fluid_midi_router_clear_rules))GetProcAddress(hmodFluidSynth, "fluid_midi_router_clear_rules")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_midi_router_rule_set_chan = (decltype(FS_fluid_midi_router_rule_set_chan))GetProcAddress(hmodFluidSynth, "fluid_midi_router_rule_set_chan")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_midi_router_rule_set_param1 = (decltype(FS_fluid_midi_router_rule_set_param1))GetProcAddress(hmodFluidSynth, "fluid_midi_router_rule_set_param1")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_midi_router_rule_set_param2 = (decltype(FS_fluid_midi_router_rule_set_param2))GetProcAddress(hmodFluidSynth, "fluid_midi_router_rule_set_param2")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_midi_router_add_rule = (decltype(FS_fluid_midi_router_add_rule))GetProcAddress(hmodFluidSynth, "fluid_midi_router_add_rule")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_delete_fluid_midi_router = (decltype(FS_delete_fluid_midi_router))GetProcAddress(hmodFluidSynth, "delete_fluid_midi_router")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_delete_fluid_audio_driver = (decltype(FS_delete_fluid_audio_driver))GetProcAddress(hmodFluidSynth, "delete_fluid_audio_driver")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_delete_fluid_player = (decltype(FS_delete_fluid_player))GetProcAddress(hmodFluidSynth, "delete_fluid_player")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_delete_fluid_synth = (decltype(FS_delete_fluid_synth))GetProcAddress(hmodFluidSynth, "delete_fluid_synth")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_delete_fluid_settings = (decltype(FS_delete_fluid_settings))GetProcAddress(hmodFluidSynth, "delete_fluid_settings")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_midi_event_get_type = (decltype(FS_fluid_midi_event_get_type))GetProcAddress(hmodFluidSynth, "fluid_midi_event_get_type")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_midi_event_get_channel = (decltype(FS_fluid_midi_event_get_channel))GetProcAddress(hmodFluidSynth, "fluid_midi_event_get_channel")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_player_set_playback_callback = (decltype(FS_fluid_player_set_playback_callback))GetProcAddress(hmodFluidSynth, "fluid_player_set_playback_callback")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_synth_all_sounds_off = (decltype(FS_fluid_synth_all_sounds_off))GetProcAddress(hmodFluidSynth, "fluid_synth_all_sounds_off")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_set_log_function = (decltype(FS_fluid_set_log_function))GetProcAddress(hmodFluidSynth, "fluid_set_log_function")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_settings_setint = (decltype(FS_fluid_settings_setint))GetProcAddress(hmodFluidSynth, "fluid_settings_setint")) == NULL)
-		bUseFluidSynth = FALSE;
-	if ((FS_fluid_settings_setnum = (decltype(FS_fluid_settings_setnum))GetProcAddress(hmodFluidSynth, "fluid_settings_setnum")) == NULL)
-		bUseFluidSynth = FALSE;
-
-	// If any of our loads failed, release the FluidSynth library, throw an error, and fall 
-	// back to using MCI.
-	if (!bUseFluidSynth) {
-		ConsoleLog(LOG_ERROR, "MUS:  One or more FluidSynth functions could not be loaded. Disabling FluidSynth.\n");
-		FreeLibrary(hmodFluidSynth);
-		hmodFluidSynth = NULL;
-		return FALSE;
-	}
-
-	if (mus_debug & MUS_DEBUG_FLUIDSYNTH)
-		ConsoleLog(LOG_DEBUG, "MUS:  Loaded FluidSynth function pointers.\n");
-
-	// Set FluidSynth's log functions
-	FS_fluid_set_log_function(FLUID_PANIC, MusicFluidSynthLoggerError, NULL);
-	FS_fluid_set_log_function(FLUID_ERR, MusicFluidSynthLoggerError, NULL);
-	FS_fluid_set_log_function(FLUID_WARN, MusicFluidSynthLoggerWarning, NULL);
-	FS_fluid_set_log_function(FLUID_INFO, NULL, NULL);
-	FS_fluid_set_log_function(FLUID_DBG, NULL, NULL);
-
-	// Create initial FluidSynth data
-	pFluidSynthSettings = FS_new_fluid_settings();
-	pFluidSynthSynth = FS_new_fluid_synth(pFluidSynthSettings);
-
-	return TRUE;
-}
-
-DWORD WINAPI FluidSynthWatchdogThread(LPVOID lpParameter) {
-	const char* szSongPath = (const char*)lpParameter;
-
-	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
-		ConsoleLog(LOG_DEBUG, "MUS:  Starting new FluidSynth watchdog thread.\n");
-	
-	// Stop and delete the existing player-driver combo if it exists
-	if (pFluidSynthPlayer) {
-		FS_fluid_player_stop(pFluidSynthPlayer);
-		for (int i = 0; i < 16; i++)
-			FS_fluid_synth_all_sounds_off(pFluidSynthSynth, i);
-		FS_delete_fluid_audio_driver(pFluidSynthDriver);
-		FS_delete_fluid_player(pFluidSynthPlayer);
-	}
-
-	// Spin up a new player-driver combo
-	pFluidSynthPlayer = FS_new_fluid_player(pFluidSynthSynth);
-	if (FS_fluid_is_soundfont(jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SOUNDFONT].ToString().c_str()))
-		FS_fluid_synth_sfload(pFluidSynthSynth, jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SOUNDFONT].ToString().c_str(), 1);
-	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
-		ConsoleLog(LOG_DEBUG, "MUS:  Loaded soundfont \"%s\" into new pFluidSynthPlayer.\n", jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SOUNDFONT].ToString().c_str());
-
-	FS_fluid_player_set_playback_callback(pFluidSynthPlayer, MusicFluidSynthMidiEventHandler, pFluidSynthSynth);
-	FS_fluid_player_add(pFluidSynthPlayer, szSongPath);
-	pFluidSynthDriver = FS_new_fluid_audio_driver(pFluidSynthSettings, pFluidSynthSynth);
-	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
-		ConsoleLog(LOG_DEBUG, "MUS:  Loaded MIDI file \"%s\" into pFluidSynthPlayer.\n", szSongPath);
-
-	// Disable chorus and set reverb and gain to the default level used by Roland synthesizers
-	// Also update the music volume here
-	FS_fluid_settings_setint(pFluidSynthSettings, "synth.chorus.active", 0);
-	FS_fluid_settings_setnum(pFluidSynthSettings, "synth.reverb.level", 0.3);
-	FS_fluid_settings_setnum(pFluidSynthSettings, "synth.gain", 0.5 * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICVOLUME].ToFloat() * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MASTERVOLUME].ToFloat());
-
-	// Play track
-	FS_fluid_player_play(pFluidSynthPlayer);
-	bFluidSynthPlaying = TRUE;
-	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
-		ConsoleLog(LOG_DEBUG, "MUS:  Started playback on pFluidSynthPlayer; watchdog thread joining player thread.\n");
-	
-	// Wait until the FluidSynth player thread exits
-	FS_fluid_player_join(pFluidSynthPlayer);
-
-	// Mark our setup as dead
-	bFluidSynthPlaying = FALSE;
-	iPlayingSongID = 0;
-
-	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
-		ConsoleLog(LOG_DEBUG, "MUS:  Exiting FluidSynth watchdog thread.\n");
-
-	// Sleep for 250ms to ensure we don't overlap reverb with a new song
-	Sleep(250);
-
-	// Avoid memory leaks -- free the string we were passed
-	free(lpParameter);
-	return 0;
 }
 
 const char* MusicEngineIntToString(UINT iMusicEngine);
@@ -436,13 +182,13 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 					ConsoleLog(LOG_DEBUG, "MUS:  Music driver set to None; ignoring WM_MUSIC_STOP message.\n");
 
 			// Stop the FluidSynth thread if it's active
-			if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() == "fluidsynth" && hmodFluidSynth) {
-				if (pFluidSynthPlayer)
-					FS_fluid_player_stop(pFluidSynthPlayer);
-				bFluidSynthPlaying = FALSE;
-				if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
-					ConsoleLog(LOG_DEBUG, "MUS:  Thread stopped FluidSynth player due to WM_MUSIC_STOP message.\n");
-				goto next;
+			if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() == "fluidsynth") {
+				if (hmodFluidSynth) {
+					PostThreadMessageA(dwFSMIDIThreadID, WM_FS_STOP, 0, 0);
+					if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
+						ConsoleLog(LOG_DEBUG, "MUS:  Thread stopped FluidSynth player due to WM_MUSIC_STOP message.\n");
+					goto next;
+				}
 			}
 
 			// If we're playing an MP3, stop it and unload it from memory
@@ -485,19 +231,19 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 			// If we're using FluidSynth, set up a watchdog thread that runs the FluidSynth engine
 			// and waits for it to exit
 			if (pSCApp->dwSCAGameMusic) {
-				if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() == "fluidsynth" && hmodFluidSynth) {
-					if (msg.wParam >= 10000 && msg.wParam <= 10018) {
-						iPlayingSongID = msg.wParam;
-						char* szSongPath = _strdup(GetGameMusicSoundPath(iPlayingSongID, FALSE));
-						if (mus_debug & MUS_DEBUG_FLUIDSYNTH)
-							ConsoleLog(LOG_DEBUG, "MUS:  GetGameMusicSoundPath(%d, FALSE) returned \"%s\".\n", iPlayingSongID, szSongPath);
+				if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() == "fluidsynth") {
+					if (hmodFluidSynth) {
+						if (msg.wParam >= 10000 && msg.wParam <= 10018) {
+							iPlayingSongID = msg.wParam;
+							const char* szSongPath = GetGameMusicSoundPath(iPlayingSongID, FALSE);
 
-						if (szSongPath && !bFluidSynthPlaying)
-							CreateThread(NULL, 0, FluidSynthWatchdogThread, (LPVOID)szSongPath, 0, NULL);
-						else
-							free(szSongPath);
-						goto next;
+							if (szSongPath)
+								PostThreadMessageA(dwFSMIDIThreadID, WM_FS_PLAY, iPlayingSongID, 0);
+							goto next;
+						}
 					}
+					else
+						ConsoleLog(LOG_ERROR, "MUS: FluidSynth not loaded; failing back to MIDI sequencer.\n");
 				}
 
 				// Attempt MP3 playback via SDL3 if we've got it selected
@@ -561,11 +307,12 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 		}
 		else if (msg.message == WM_MUSIC_RESET) {
 			// Attempt to hard stop all music engines, since our music engine has probably changed
-			if (bFluidSynthPlaying && hmodFluidSynth) {
-				FS_fluid_player_stop(pFluidSynthPlayer);
-				bFluidSynthPlaying = FALSE;
-				if (mus_debug & MUS_DEBUG_THREAD)
-					ConsoleLog(LOG_DEBUG, "MUS:  Thread stopped FluidSynth player due to WM_MUSIC_RESET message.\n");
+			if (hmodFluidSynth) {
+				if (bFluidSynthPlaying) {
+					PostThreadMessageA(dwFSMIDIThreadID, WM_FS_STOP, 0, 0);
+					if (mus_debug & MUS_DEBUG_THREAD)
+						ConsoleLog(LOG_DEBUG, "MUS:  Thread stopped FluidSynth player due to WM_MUSIC_RESET message.\n");
+				}
 			}
 
 			if (pStreamCurrentSong) {

--- a/modules/sound_engine.cpp
+++ b/modules/sound_engine.cpp
@@ -220,11 +220,10 @@ DWORD WINAPI SDLSongThread(LPVOID lpParameter) {
 
 	while (GetMessage(&msg, NULL, 0, 0)) {
 		if (msg.message == WM_SDL_PLAY) {
-			int iPlayingSongID = (int)msg.wParam;
-			if (iPlayingSongID >= 10000 && iPlayingSongID <= 10018) {
+			if (msg.wParam >= 10000 && msg.wParam <= 10018) {
 				if (bSongPlaying)
 					goto next;
-				const char* szSongPath = GetGameMusicSoundPath(iPlayingSongID, TRUE);
+				const char* szSongPath = GetGameMusicSoundPath(TRUE);
 				if (szSongPath) {
 					//uint64_t uTickStart = GetTickCount64();
 					LARGE_INTEGER uTickStart, uTickEnd, uTicksPerSecond;

--- a/modules/sound_engine.cpp
+++ b/modules/sound_engine.cpp
@@ -302,6 +302,7 @@ DWORD WINAPI SoundEngineOneShotThread(LPVOID lpParameter) {
 	bSoundPlaying = false;
 	return EXIT_SUCCESS;
 }
+
 DWORD WINAPI SoundEngineSongThread(LPVOID lpParameter) {
 	audio_entity_t* stAudioData = (audio_entity_t*)lpParameter;
 
@@ -430,10 +431,6 @@ bool SoundEnginePlayStream(SDL_AudioStream** pStream, audio_entity_t* stAudioDat
 		stAudioData->iSampleRate
 	};
 
-	/**pStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
-	if (!*pStream)
-		ConsoleLog(LOG_ERROR, "SND:  SDL_OpenAudioDeviceStream failed: %s.\n", SDL_GetError());*/
-
 	SDL_SetAudioStreamFormat(*pStream, &spec, NULL);
 	SDL_SetAudioStreamGain(*pStream, fVolume);
 	SDL_PutAudioStreamData(*pStream, stAudioData->pBuffer, stAudioData->uBufferSize);
@@ -477,10 +474,6 @@ bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData,
 		stAudioData->iChannels,
 		stAudioData->iSampleRate
 	};
-
-	/**pStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
-	if (!*pStream)
-		ConsoleLog(LOG_ERROR, "SND:  SDL_OpenAudioDeviceStream failed: %s.\n", SDL_GetError());*/
 
 	SDL_SetAudioStreamGain(*pStream, fVolume);
 	SDL_PutAudioStreamData(*pStream, stAudioData->pBuffer, stAudioData->uBufferSize);

--- a/sc2kfix.vcxproj
+++ b/sc2kfix.vcxproj
@@ -162,6 +162,7 @@ const char* szSC2KFixBuildInfo = "$(UserName)@$(ComputerName)  $([System.DateTim
     <ClCompile Include="hooks\hook_sndPlaySound.cpp" />
     <ClCompile Include="hooks\hook_mmtimers.cpp" />
     <ClCompile Include="modules\console_new.cpp" />
+    <ClCompile Include="modules\fluidsynth_engine.cpp" />
     <ClCompile Include="modules\game_graphics.cpp" />
     <ClCompile Include="modules\keybindings.cpp" />
     <ClCompile Include="modules\lua_glue.cpp" />

--- a/sc2kfix.vcxproj.filters
+++ b/sc2kfix.vcxproj.filters
@@ -488,6 +488,9 @@
     <ClCompile Include="hooks\hook_scenario.cpp">
       <Filter>Source Files\Hooks</Filter>
     </ClCompile>
+    <ClCompile Include="modules\fluidsynth_engine.cpp">
+      <Filter>Source Files\Modules</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="sc2kfix.rc">


### PR DESCRIPTION
1) Moved the FluidSynth code to its own specific source file.
2) A bit of re-structuring performed in-order to move the stop/play calls into its own dedicated thread.
3) Further tweaks have been made to avoid a rare crash during music override situations (the nature of this specific crash only had an effect on the FluidSynth thread and consequently allowed the game to keep running).