### PR TITLE
Music tweaks (mostly)

### DIFF
--- a/hooks/hook_animation.cpp
+++ b/hooks/hook_animation.cpp
@@ -10,8 +10,6 @@
 
 #include <sc2kfix.h>
 
-static DWORD dwDummy;
-
 HWND hWndExt = 0;
 
 __int16 nCycleIdx = 0;

--- a/hooks/hook_drawing.cpp
+++ b/hooks/hook_drawing.cpp
@@ -53,8 +53,6 @@ extern BOOL bMapWireFrame;
 
 UINT mdrawing_debug = MDRAWING_DEBUG;
 
-static DWORD dwDummy;
-
 static int DoWaterfallEdge(__int16 iMapOffSetX, int iX, int iY, __int16 iBottom, __int16 iWaterFallSpriteID, __int16 nLandAltScale) {
 	__int16 iTopog;
 

--- a/hooks/hook_guzzardo.cpp
+++ b/hooks/hook_guzzardo.cpp
@@ -27,8 +27,6 @@
 
 UINT guzzardo_debug = GUZZARDO_DEBUG;
 
-static DWORD dwDummy; 
-
 #define NUM_CHEATS 15
 #define NUM_CHEAT_MAXCHARS 9
 

--- a/hooks/hook_movies.cpp
+++ b/hooks/hook_movies.cpp
@@ -25,8 +25,6 @@
 
 UINT mov_debug = MOVIE_DEBUG;
 
-static DWORD dwDummy;
-
 extern int nMovZoomFactor;
 
 BOOL bSkipIntro = FALSE;

--- a/hooks/hook_querydialog.cpp
+++ b/hooks/hook_querydialog.cpp
@@ -21,8 +21,6 @@
 #include <sc2kfix.h>
 #include "../resource.h"
 
-static DWORD dwDummy;
-
 extern BOOL PrepareDialogSpriteGraphic_SC2K1996(CGraphics *pGraphic, HWND hWnd, sprite_header_t *pSprHead, __int16 nSpriteID, CMFC3XRect *pDlgRect, __int16 isFlipped = 0, __int16 doInvert = 0, int nType = PALCACHE_TYPE_NONE);
 extern void ShowCurrentDialogSpriteGraphic_SC2K1996(CGraphics *pGraphic, HWND hWnd, sprite_header_t *pSprHead, __int16 nSpriteID, CMFC3XRect *pDlgRect, BOOL bSpriteFail, __int16 isFlipped = 0, __int16 doInvert = 0, int nType = PALCACHE_TYPE_NONE);
 

--- a/hooks/hook_sc2k1995_miscellaneous.cpp
+++ b/hooks/hook_sc2k1995_miscellaneous.cpp
@@ -33,8 +33,6 @@
 
 UINT mischook_1995_debug = MISCHOOK_1995_DEBUG;
 
-static DWORD dwDummy;
-
 extern "C" int __stdcall Hook_1995_LoadStringA(HINSTANCE hInstance, UINT uID, LPSTR lpBuffer, int cchBufferMax) {
 	if (hInstance == hSC2KAppModule) {
 		switch (uID) {

--- a/hooks/hook_sc2k1996_miscellaneous.cpp
+++ b/hooks/hook_sc2k1996_miscellaneous.cpp
@@ -809,7 +809,7 @@ extern "C" void __stdcall Hook_SimcityApp_BuildSubFrames(void) {
 				pThis->iSCAProgramStep = ONIDLE_STATE_DISPLAYMAXIS;
 				if (!bSkipIntro && !jsonSettingsCore[C_SC2KFIX][S_FIX_QOL][I_FIX_QOL_SKIPINTRO].ToBool()) {
 					if (Game_MovieCheck(aIntroASmk) && Game_MovieCheck(aIntroBSmk)) {
-						if (!Game_Sound_GetMCIResult(pThis->SCASNDLayer))
+						if (!Game_Sound_IsMusicPlaying(pThis->SCASNDLayer))
 							Game_SimcityApp_MusicTrigger(pThis);
 						if (Game_MovieCreateWindow()) {
 							if (!Game_MovieOpen(aIntroASmk))
@@ -820,7 +820,7 @@ extern "C" void __stdcall Hook_SimcityApp_BuildSubFrames(void) {
 					else
 						pThis->iSCAProgramStep = ONIDLE_STATE_DISPLAYINFLIGHT;
 				}
-				if (!Game_Sound_GetMCIResult(pThis->SCASNDLayer))
+				if (!Game_Sound_IsMusicPlaying(pThis->SCASNDLayer))
 					Game_SimcityApp_MusicPlayNextRefocusSong(pThis);
 				pThis->dwSCASetNextStep = TRUE;
 			}
@@ -2025,7 +2025,7 @@ extern "C" void __stdcall Hook_MainFrame_OnActivateApp(BOOL bActive, HTASK hTask
 				InvalidateRect(pThis->m_hWnd, 0, TRUE);
 				Game_MainFrame_ToggleToolBars(pThis, TRUE);
 				if (pSCView) {
-					if (!Game_Sound_GetMCIResult(pSCApp->SCASNDLayer))
+					if (!Game_Sound_IsMusicPlaying(pSCApp->SCASNDLayer))
 						Game_SimcityApp_MusicPlayNextRefocusSong(pSCApp);
 					// Added to get things going again.
 					bSoundKickstart = true;
@@ -2075,7 +2075,7 @@ extern "C" void __stdcall Hook_MainFrame_OnShowWindow(BOOL bShow, BOOL nStatus) 
 		InvalidateRect(pThis->m_hWnd, 0, TRUE);
 		Game_MainFrame_ToggleToolBars(pThis, TRUE);
 		if (pSCView) {
-			if (!Game_Sound_GetMCIResult(pSCApp->SCASNDLayer))
+			if (!Game_Sound_IsMusicPlaying(pSCApp->SCASNDLayer))
 				Game_SimcityApp_MusicPlayNextRefocusSong(pSCApp);
 			// Added to get things going again.
 			bSoundKickstart = true;

--- a/hooks/hook_sc2k1996_miscellaneous.cpp
+++ b/hooks/hook_sc2k1996_miscellaneous.cpp
@@ -50,8 +50,6 @@
 
 UINT mischook_debug = MISCHOOK_DEBUG;
 
-static DWORD dwDummy;
-
 DLGPROC lpNewCityAfxProc = NULL;
 char szTempMayorName[24] = { 0 };
 

--- a/hooks/hook_sc2kdemo_miscellaneous.cpp
+++ b/hooks/hook_sc2kdemo_miscellaneous.cpp
@@ -30,8 +30,6 @@
 
 UINT mischook_demo_debug = MISCHOOK_DEMO_DEBUG;
 
-static DWORD dwDummy;
-
 #pragma warning(disable : 6387)
 // Hook LoadMenuA so we can insert our own menu items.
 extern "C" HMENU __stdcall Hook_Demo_LoadMenuA(HINSTANCE hInstance, LPCSTR lpMenuName) {
@@ -296,7 +294,7 @@ void InstallMiscHooks_SC2KDemo(void) {
 skipmainmenu:
 	;
 	// Experiment with nullifying the timer during the first load.
-	//SafeVirtualProtect((LPVOID)0x47685E, 10, PAGE_EXECUTE_READWRITE, &dwDummy);
+	//SafeVirtualProtect((LPVOID)0x47685E, 10, PAGE_EXECUTE_READWRITE);
 	//BYTE bTimePatch[10] = { 0xC7, 0x05, 0x68, 0x6A, 0x4B, 0x00, 0xFF, 0xFF, 0x00, 0x00 };
 	//memcpy((LPVOID)0x47685E, bTimePatch, 10);
 }

--- a/hooks/hook_sndPlaySound.cpp
+++ b/hooks/hook_sndPlaySound.cpp
@@ -114,7 +114,7 @@ extern "C" void __stdcall Hook_Sound_InitSoundLayer(HWND m_hWnd) {
 	pThis->hMainWnd = m_hWnd;
 	GameMain_String_Empty(&pThis->dwSNDMusicString);
 	pThis->dwSNDUnknownOne = 0;
-	pThis->dwSNDMCIError = 0;
+	pThis->dwSNDMusPlaying = 0;
 	pThis->dwSNDUnknownTwo = -1;
 	pThis->bSNDPlaySound = FALSE;
 	pThis->bSNDWasPlaying = FALSE;

--- a/hooks/hook_sndPlaySound.cpp
+++ b/hooks/hook_sndPlaySound.cpp
@@ -34,8 +34,6 @@ std::map<int, audio_entity_t> mapSoundCache;
 
 bool bSoundKickstart = false;
 
-static DWORD dwDummy;
-
 static bool LoadSoundFromFile(int iSoundID, std::string strPath);
 
 static int GetSoundPosBySoundID(int iSoundID) {

--- a/hooks/hook_sndPlaySound.cpp
+++ b/hooks/hook_sndPlaySound.cpp
@@ -474,11 +474,11 @@ static bool LoadSoundFromFile(int iSoundID, std::string strPath) {
 	}
 
 	// Build the audio entity data
-	stAudioEntity.iFrames = stSoundFileInfo.frames;
+	stAudioEntity.iFrames = (int)stSoundFileInfo.frames;
 	stAudioEntity.iSampleRate = stSoundFileInfo.samplerate;
 	stAudioEntity.iChannels = stSoundFileInfo.channels;
 	stAudioEntity.iFormat = stSoundFileInfo.format;
-	stAudioEntity.bSeekable = stSoundFileInfo.seekable;
+	stAudioEntity.bSeekable = stSoundFileInfo.seekable ? true : false;
 	stAudioEntity.uBufferSize = stAudioEntity.iChannels * sizeof(short) * stAudioEntity.iFrames;
 	stAudioEntity.pBuffer = (short*)malloc(stAudioEntity.uBufferSize);
 	if (!stAudioEntity.pBuffer) {

--- a/hooks/hook_spritesandtilesets.cpp
+++ b/hooks/hook_spritesandtilesets.cpp
@@ -29,8 +29,6 @@
 
 UINT sprite_debug = SPRITE_DEBUG;
 
-static DWORD dwDummy; 
-
 std::vector<sprite_ids_t> spriteIDs;
 
 static BOOL CheckForExistingID(WORD nID) {

--- a/hooks/hook_tilegrowthorplacement.cpp
+++ b/hooks/hook_tilegrowthorplacement.cpp
@@ -80,8 +80,6 @@
 
 UINT tilebuild_debug = TILEBUILD_DEBUG;
 
-static DWORD dwDummy;
-
 #if USE_NEW_STARTINGCOORDS
 CPoint dwTripStartingCoords[24] = {
 	{ 0, 1 },

--- a/hooks/hook_toolbars.cpp
+++ b/hooks/hook_toolbars.cpp
@@ -28,8 +28,6 @@
 
 UINT toolbar_debug = TOOLBAR_DEBUG;
 
-static DWORD dwDummy;
-
 extern "C" void __stdcall Hook_CityToolBar_ToolMenuDisable() {
 	CCityToolBar *pThis;
 

--- a/include/music.h
+++ b/include/music.h
@@ -30,12 +30,14 @@ enum {
 };
 
 void InstallMusicEngineHooks(void);
+void SetMCIDevID(__int16 wMCIDevID);
+void SetSongPlaying(bool bPlaying);
+bool IsSongPlaying();
 const char *GetGameMusicSoundPath(BOOL bDoMP3);
 DWORD WINAPI MusicThread(LPVOID lpParameter);
 void MusicShufflePlaylist(int iLastSongPlayed);
 
 extern BOOL bUseMultithreadedMusic;
-extern bool bFluidSynthPlaying;
 extern DWORD dwMusicThreadID;
 extern DWORD dwFSMIDIThreadID;
 

--- a/include/music.h
+++ b/include/music.h
@@ -35,9 +35,7 @@ void SetSongPlaying(bool bPlaying);
 bool IsSongPlaying();
 const char *GetGameMusicSoundPath(BOOL bDoMP3);
 DWORD WINAPI MusicThread(LPVOID lpParameter);
-void MusicShufflePlaylist(int iLastSongPlayed);
 
-extern BOOL bUseMultithreadedMusic;
 extern DWORD dwMusicThreadID;
 extern DWORD dwFSMIDIThreadID;
 

--- a/include/sc2k_1996.h
+++ b/include/sc2k_1996.h
@@ -3005,7 +3005,7 @@ GAMECALL(0x40144C, void, __thiscall, SimcityApp_NewCity, CSimcityAppPrimary *)
 GAMECALL(0x401460, BYTE, __cdecl, SimulationProvisionMicrosim, __int16, __int16, __int16 iTileID) // The first two arguments aren't clear, though they "could" be the X/Y tile coordinates.
 GAMECALL(0x40146A, void, __cdecl, LoadNamedEntryFromRsrcOffset, char *, int, int)
 GAMECALL(0x40147E, int, __thiscall, Graphics_CreateWithPalette, CGraphics *, LONG, LONG)
-GAMECALL(0x40148D, DWORD, __thiscall, Sound_GetMCIResult, CSound *)
+GAMECALL(0x40148D, DWORD, __thiscall, Sound_IsMusicPlaying, CSound *)
 GAMECALL(0x4014B0, void, __cdecl, InitStack, __int16, __int16)
 GAMECALL(0x4014CE, int, __cdecl, SpawnAeroplane, __int16 x, __int16 y, __int16 iDirection)
 GAMECALL(0x4014EC, void, __cdecl, CityToolPlaceNature, CMFC3XPoint)

--- a/include/sc2kclasses.h
+++ b/include/sc2kclasses.h
@@ -153,8 +153,8 @@ public:
 	void *dwSNDBufferGeneral;
 	int iSNDGeneralSoundID;
 	DWORD dwSNDUnknownOne;
-	WORD wSNDMCIDevID;
-	DWORD dwSNDMCIError;
+	__int16 wSNDMCIDevID;
+	DWORD dwSNDMusPlaying;
 	DWORD dwSNDUnknownTwo;
 	CMFC3XString dwSNDMusicString;
 };

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -503,7 +503,6 @@ DWORD WINAPI UpdaterThread(LPVOID lpParameter);
 const char *GetGameSoundPath();
 int GetCurrentActiveSongID();
 bool MusicLoadFluidSynth(void);
-void DoMusicPlay(int iSongID, BOOL bInterrupt);
 const char* MusicEngineIntToString(UINT iMusicEngine);
 UINT MusicEngineStringToInt(const char* szMusicEngine);
 BOOL DoConfigureMusicTracks(settings_t *st, HWND hDlg, BOOL bMP3);

--- a/include/sound_engine.h
+++ b/include/sound_engine.h
@@ -72,6 +72,8 @@ extern SDL_AudioStream* pStreamCurrentSound;
 extern DWORD dwSDLSoundThreadID;
 extern DWORD dwSDLSongThreadID;
 
+extern bool bSongPlaying;
+
 extern SNDFILE* (*SF_open)(const char* path, int mode, SF_INFO* sfinfo);
 extern SNDFILE* (*SF_open_virtual)(SF_VIRTUAL_IO* sfvirtual, int mode, SF_INFO* sfinfo, void* user_data);
 extern sf_count_t(*SF_seek)(SNDFILE* sndfile, sf_count_t frames, int whence);

--- a/include/sound_engine.h
+++ b/include/sound_engine.h
@@ -101,4 +101,4 @@ void SoundEngineDestroy(void);
 void SoundEngineStopStream(SDL_AudioStream** pStream);
 bool SoundEnginePlayStream(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume, bool bOverride, bool bLoop);
 void SoundEngineStopSong(SDL_AudioStream** pStream);
-bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume, bool bOverride);
+bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume);

--- a/include/sound_engine.h
+++ b/include/sound_engine.h
@@ -93,7 +93,3 @@ DWORD WINAPI SDLSongThread(LPVOID lpParameter);
 bool LoadSoundEngineLibraries(void);
 bool SoundEngineInitialize(void);
 void SoundEngineDestroy(void);
-void SoundEngineStopStream(SDL_AudioStream** pStream);
-bool SoundEnginePlayStream(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume, bool bOverride, bool bLoop);
-void SoundEngineStopSong(SDL_AudioStream** pStream);
-bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume);

--- a/include/sound_engine.h
+++ b/include/sound_engine.h
@@ -63,9 +63,6 @@ typedef void* SDL_AudioStreamCallback;
 
 #define SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK ((SDL_AudioDeviceID) 0xFFFFFFFFu)
 
-extern HMODULE hmodSndFile;
-extern HMODULE hmodSDL3;
-
 extern SDL_AudioStream* pStreamCurrentSong;
 extern SDL_AudioStream* pStreamCurrentSound;
 

--- a/include/sound_engine.h
+++ b/include/sound_engine.h
@@ -72,8 +72,6 @@ extern SDL_AudioStream* pStreamCurrentSound;
 extern DWORD dwSDLSoundThreadID;
 extern DWORD dwSDLSongThreadID;
 
-extern bool bSongPlaying;
-
 extern SNDFILE* (*SF_open)(const char* path, int mode, SF_INFO* sfinfo);
 extern SNDFILE* (*SF_open_virtual)(SF_VIRTUAL_IO* sfvirtual, int mode, SF_INFO* sfinfo, void* user_data);
 extern sf_count_t(*SF_seek)(SNDFILE* sndfile, sf_count_t frames, int whence);

--- a/modules/fluidsynth_engine.cpp
+++ b/modules/fluidsynth_engine.cpp
@@ -21,7 +21,6 @@
 
 HMODULE hmodFluidSynth = NULL;
 DWORD dwFSMIDIThreadID = 0;
-bool bFluidSynthPlaying = false;
 
 static HANDLE hCurrentFSSongThread = 0;
 static BOOL bUseFluidSynth = FALSE;
@@ -249,9 +248,8 @@ static void FluidSynthStopSong(fluid_audio_driver_t** pAudDriver, fluid_synth_t*
 		*pPlayer = 0;
 	}
 
-	pSound->wSNDMCIDevID = -1;
-	pSound->dwSNDMusPlaying = 0;
-	bFluidSynthPlaying = false;
+	SetMCIDevID(-1);
+	SetSongPlaying(false);
 }
 
 static DWORD WINAPI FluidSynthSongThread(LPVOID lpParameter) {
@@ -276,7 +274,8 @@ static DWORD WINAPI FluidSynthSongThread(LPVOID lpParameter) {
 		ConsoleLog(LOG_DEBUG, "MUS: Exiting FluidSynth song 'join' monitoring thread.\n");
 
 	bFSSongThreadActive = false;
-	bFluidSynthPlaying = false;
+	SetMCIDevID(-1);
+	SetSongPlaying(false);
 
 	// In the old watchdog thread there was a sleep call at
 	// the end that was present to avoid any reverb-effect
@@ -326,12 +325,10 @@ static bool FluidSynthPlaySong(fluid_audio_driver_t** pAudDriver, fluid_synth_t*
 
 	// Play track
 	FS_fluid_player_play(*pPlayer);
-	bFluidSynthPlaying = true;
 	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
 		ConsoleLog(LOG_DEBUG, "MUS:  Started playback on pFluidSynthPlayer; joining player thread.\n");
 
-	pSound->wSNDMCIDevID = 1;
-	pSound->dwSNDMusPlaying = 1;
+	SetSongPlaying(true);
 
 	hCurrentFSSongThread = CreateThread(NULL, 0, FluidSynthSongThread, *pPlayer, 0, NULL);
 
@@ -353,7 +350,7 @@ DWORD WINAPI FSMIDIThread(LPVOID lpParameter) {
 	while (GetMessage(&msg, NULL, 0, 0)) {
 		if (msg.message == WM_FS_PLAY) {
 			if (msg.wParam >= 10000 && msg.wParam <= 10018) {
-				if (bFluidSynthPlaying)
+				if (IsSongPlaying())
 					goto next;
 				const char* szSongPath = GetGameMusicSoundPath(FALSE);
 				if (szSongPath)

--- a/modules/fluidsynth_engine.cpp
+++ b/modules/fluidsynth_engine.cpp
@@ -286,13 +286,10 @@ static DWORD WINAPI FluidSynthSongThread(LPVOID lpParameter) {
 	return EXIT_SUCCESS;
 }
 
-static bool FluidSynthPlaySong(fluid_audio_driver_t** pAudDriver, fluid_synth_t** pSynth, fluid_settings_t** pSettings, fluid_player_t** pPlayer, const char *szSongPath, bool bOverride) {
+static bool FluidSynthPlaySong(fluid_audio_driver_t** pAudDriver, fluid_synth_t** pSynth, fluid_settings_t** pSettings, fluid_player_t** pPlayer, const char *szSongPath) {
 	CSimcityAppPrimary *pSCApp = &pCSimcityAppThis;
 	CSound *pSound = pSCApp->SCASNDLayer;
 	if (!pPlayer)
-		return false;
-
-	if (!bOverride && bFluidSynthPlaying)
 		return false;
 
 	FluidSynthStopSong(pAudDriver, pSynth, pPlayer);
@@ -360,7 +357,7 @@ DWORD WINAPI FSMIDIThread(LPVOID lpParameter) {
 					goto next;
 				const char* szSongPath = GetGameMusicSoundPath(FALSE);
 				if (szSongPath)
-					FluidSynthPlaySong(&pFluidSynthDriver, &pFluidSynthSynth, &pFluidSynthSettings, &pFluidSynthPlayer, szSongPath, true);
+					FluidSynthPlaySong(&pFluidSynthDriver, &pFluidSynthSynth, &pFluidSynthSettings, &pFluidSynthPlayer, szSongPath);
 			}
 		}
 		else if (msg.message == WM_FS_STOP)

--- a/modules/fluidsynth_engine.cpp
+++ b/modules/fluidsynth_engine.cpp
@@ -207,6 +207,8 @@ bool MusicLoadFluidSynth(void) {
 }
 
 static void FluidSynthStopSong(fluid_audio_driver_t** pAudDriver, fluid_synth_t** pSynth, fluid_player_t** pPlayer) {
+	CSimcityAppPrimary *pSCApp = &pCSimcityAppThis;
+	CSound *pSound = pSCApp->SCASNDLayer;
 	int i;
 	
 	if (!pAudDriver && !pSynth && !pPlayer)
@@ -247,6 +249,8 @@ static void FluidSynthStopSong(fluid_audio_driver_t** pAudDriver, fluid_synth_t*
 		*pPlayer = 0;
 	}
 
+	pSound->wSNDMCIDevID = -1;
+	pSound->dwSNDMusPlaying = 0;
 	bFluidSynthPlaying = false;
 }
 
@@ -283,6 +287,8 @@ static DWORD WINAPI FluidSynthSongThread(LPVOID lpParameter) {
 }
 
 static bool FluidSynthPlaySong(fluid_audio_driver_t** pAudDriver, fluid_synth_t** pSynth, fluid_settings_t** pSettings, fluid_player_t** pPlayer, const char *szSongPath, bool bOverride) {
+	CSimcityAppPrimary *pSCApp = &pCSimcityAppThis;
+	CSound *pSound = pSCApp->SCASNDLayer;
 	if (!pPlayer)
 		return false;
 
@@ -326,6 +332,9 @@ static bool FluidSynthPlaySong(fluid_audio_driver_t** pAudDriver, fluid_synth_t*
 	bFluidSynthPlaying = true;
 	if (mus_debug & MUS_DEBUG_THREAD || mus_debug & MUS_DEBUG_FLUIDSYNTH)
 		ConsoleLog(LOG_DEBUG, "MUS:  Started playback on pFluidSynthPlayer; joining player thread.\n");
+
+	pSound->wSNDMCIDevID = 1;
+	pSound->dwSNDMusPlaying = 1;
 
 	hCurrentFSSongThread = CreateThread(NULL, 0, FluidSynthSongThread, *pPlayer, 0, NULL);
 

--- a/modules/fluidsynth_engine.cpp
+++ b/modules/fluidsynth_engine.cpp
@@ -206,8 +206,6 @@ bool MusicLoadFluidSynth(void) {
 }
 
 static void FluidSynthStopSong(fluid_audio_driver_t** pAudDriver, fluid_synth_t** pSynth, fluid_player_t** pPlayer) {
-	CSimcityAppPrimary *pSCApp = &pCSimcityAppThis;
-	CSound *pSound = pSCApp->SCASNDLayer;
 	int i;
 	
 	if (!pAudDriver && !pSynth && !pPlayer)
@@ -286,8 +284,6 @@ static DWORD WINAPI FluidSynthSongThread(LPVOID lpParameter) {
 }
 
 static bool FluidSynthPlaySong(fluid_audio_driver_t** pAudDriver, fluid_synth_t** pSynth, fluid_settings_t** pSettings, fluid_player_t** pPlayer, const char *szSongPath) {
-	CSimcityAppPrimary *pSCApp = &pCSimcityAppThis;
-	CSound *pSound = pSCApp->SCASNDLayer;
 	if (!pPlayer)
 		return false;
 

--- a/modules/military.cpp
+++ b/modules/military.cpp
@@ -35,8 +35,6 @@
 
 UINT military_debug = MILITARY_DEBUG;
 
-static DWORD dwDummy;
-
 static coords_w_t cornerCoords[VIEWROTATION_COUNT] = {
 	{ MAP_EDGE_MAX, MAP_EDGE_MIN },
 	{ MAP_EDGE_MIN, MAP_EDGE_MIN },

--- a/modules/music.cpp
+++ b/modules/music.cpp
@@ -14,8 +14,6 @@
 
 UINT mus_debug = MUS_DEBUG;
 
-static DWORD dwDummy;
-
 static int iPlayingSongID = 0;
 static MCIDEVICEID mciDevice = -1;
 static bool bMusicForceIntroSongOnce = true;

--- a/modules/music.cpp
+++ b/modules/music.cpp
@@ -16,8 +16,6 @@ UINT mus_debug = MUS_DEBUG;
 
 static DWORD dwDummy;
 
-extern bool bSongPlaying;
-
 static int iPlayingSongID = 0;
 std::vector<int> vectorRandomSongIDs = { 10001, 10004, 10008, 10012, 10018, 10003, 10007, 10011, 10013, 10017 };
 int iCurrentSong = 0;
@@ -170,6 +168,20 @@ const char *GetGameMusicSoundPath(BOOL bDoMP3) {
 	return strSongPath.c_str();
 }
 
+static void DoMusicPlay(int iSongID) {
+	// Always do this.
+	if (dwMusicThreadID)
+		PostThreadMessage(dwMusicThreadID, WM_MUSIC_STOP, NULL, NULL);
+	if (mus_debug & MUS_DEBUG_THREAD)
+		ConsoleLog(LOG_DEBUG, "MUS:  Hook_SimcityApp_MusicPlay posted WM_MUSIC_STOP.\n");
+
+	// Post the play message to the music thread
+	if (dwMusicThreadID)
+		PostThreadMessage(dwMusicThreadID, WM_MUSIC_PLAY, iSongID, NULL);
+	if (mus_debug & MUS_DEBUG_THREAD)
+		ConsoleLog(LOG_DEBUG, "MUS:  Hook_SimcityApp_MusicPlay posted WM_MUSIC_PLAY for iSongID = %u.\n", iSongID);
+}
+
 DWORD WINAPI MusicThread(LPVOID lpParameter) {
 	CSimcityAppPrimary *pSCApp;
 	MSG msg;
@@ -246,7 +258,6 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 					if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() == "fluidsynth") {
 						if (hmodFluidSynth) {
 							const char* szSongPath = GetGameMusicSoundPath(FALSE);
-
 							if (szSongPath)
 								PostThreadMessageA(dwFSMIDIThreadID, WM_FS_PLAY, msg.wParam, 0);
 							goto next;
@@ -310,7 +321,7 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 						pSCApp->SCASNDLayer->dwSNDMusPlaying = 1;
 					}
 					else {
-						if (mus_debug & MUS_DEBUG_THREAD && msg.lParam != 1)
+						if (mus_debug & MUS_DEBUG_THREAD)
 							ConsoleLog(LOG_DEBUG, "MUS:  WM_MUSIC_PLAY message received but MCI is still active; discarding message.\n");
 						goto next;
 					}
@@ -374,31 +385,6 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 	return EXIT_SUCCESS;
 }
 
-void DoMusicPlay(int iSongID, BOOL bInterrupt) {
-	/*if (bInterrupt)*/ {
-		// Certain songs should interrupt others
-		/*switch (iSongID)*/ {
-		/*case 10002:
-		case 10004:
-		case 10005:
-		case 10010:
-		case 10012:
-		case 10016:*/
-			if (dwMusicThreadID)
-				PostThreadMessage(dwMusicThreadID, WM_MUSIC_STOP, NULL, NULL);
-			if (mus_debug & MUS_DEBUG_THREAD)
-				ConsoleLog(LOG_DEBUG, "MUS:  Hook_SimcityApp_MusicPlay posted WM_MUSIC_STOP.\n");
-			/*break;*/
-		}
-	}
-
-	// Post the play message to the music thread
-	if (dwMusicThreadID)
-		PostThreadMessage(dwMusicThreadID, WM_MUSIC_PLAY, iSongID, (bInterrupt) ? NULL : 1);
-	if (mus_debug & MUS_DEBUG_THREAD && bInterrupt)
-		ConsoleLog(LOG_DEBUG, "MUS:  Hook_SimcityApp_MusicPlay posted WM_MUSIC_PLAY for iSongID = %u.\n", iSongID);
-}
-
 extern "C" void __stdcall Hook_MainFrame_OnMCINotify(WPARAM wFlags, LPARAM lDevID) {
 	CMainFrame *pThis;
 	__asm mov [pThis], ecx
@@ -411,7 +397,7 @@ extern "C" void __stdcall Hook_SimcityApp_MusicPlay(int iSongID) {
 	__asm mov [pThis], ecx
 
 	if (pThis->dwSCAGameMusic)
-		DoMusicPlay(iSongID, TRUE);
+		DoMusicPlay(iSongID);
 }
 
 extern "C" void __stdcall Hook_Sound_MusicStop(void) {
@@ -451,13 +437,6 @@ extern "C" void __stdcall Hook_SimcityApp_MusicPlayNextRefocusSong(void) {
 	}
 }
 
-static void L_MusicPlay(CSimcityAppPrimary *pThis, int iSongID) {
-	if (bMultithreadedMusicEnabled)
-		DoMusicPlay(iSongID, FALSE);
-	else
-		Game_SimcityApp_MusicPlay(pThis, iSongID);
-}
-
 extern "C" void __stdcall Hook_SimcityApp_MusicPlayNext(BOOL bNext) {
 	CSimcityAppPrimary *pThis;
 
@@ -478,7 +457,7 @@ extern "C" void __stdcall Hook_SimcityApp_MusicPlayNext(BOOL bNext) {
 		else if ((!(rand() % (8 * (3 * nSpeed - 3)))) || jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_ALWAYSPLAYMUSIC].ToBool()) {
 			iRandMusic = rand();
 			iSongID = 10000 + (iRandMusic % 19);
-			L_MusicPlay(pThis, iSongID);
+			Game_SimcityApp_MusicPlay(pThis, iSongID);
 		}
 	}
 }

--- a/modules/music.cpp
+++ b/modules/music.cpp
@@ -16,11 +16,13 @@ UINT mus_debug = MUS_DEBUG;
 
 static DWORD dwDummy;
 
+extern bool bSongPlaying;
+
 static int iPlayingSongID = 0;
 std::vector<int> vectorRandomSongIDs = { 10001, 10004, 10008, 10012, 10018, 10003, 10007, 10011, 10013, 10017 };
 int iCurrentSong = 0;
 DWORD dwMusicThreadID = 0;
-MCIDEVICEID mciDevice = NULL;
+MCIDEVICEID mciDevice = -1;
 BOOL bMultithreadedMusicEnabled = FALSE;
 bool bMusicForceIntroSongOnce = true;
 
@@ -206,7 +208,7 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 			}
 
 			// Failing the above, run what we need to through the MCI interface
-			if (!mciDevice)
+			if (mciDevice == -1)
 				goto next;
 
 			dwMCIError = mciSendCommand(mciDevice, MCI_CLOSE, MCI_WAIT, NULL);
@@ -224,7 +226,9 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 					ConsoleLog(LOG_ERROR, "MUS:  MCI_CLOSE failed, 0x%08X (%s)\n", dwMCIError, szErrorBuf);
 				goto next;
 			}
-			mciDevice = NULL;
+			mciDevice = -1;
+			pSCApp->SCASNDLayer->wSNDMCIDevID = mciDevice;
+			pSCApp->SCASNDLayer->dwSNDMusPlaying = 0;
 		}
 		else if (msg.message == WM_MUSIC_PLAY) {
 			// Log a debug message at best if the music engine is set to none
@@ -242,6 +246,7 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 					if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() == "fluidsynth") {
 						if (hmodFluidSynth) {
 							const char* szSongPath = GetGameMusicSoundPath(FALSE);
+
 							if (szSongPath)
 								PostThreadMessageA(dwFSMIDIThreadID, WM_FS_PLAY, msg.wParam, 0);
 							goto next;
@@ -262,11 +267,17 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 					}
 
 					// Failing all of the above, use MCI to handle MIDI playback
-					if (!mciDevice) {
+					if (mciDevice != -1) {
+						mciSendCommand(mciDevice, MCI_CLOSE, MCI_WAIT, NULL);
+						mciDevice = -1;
+					}
+
+					if (mciDevice == -1) {
 						const char* szSongPath = GetGameMusicSoundPath(FALSE);
-						if (!szSongPath)
+						if (!szSongPath || pSCApp->SCASNDLayer->dwSNDMusPlaying)
 							goto next;
 
+						pSCApp->SCASNDLayer->dwSNDMusPlaying = 1;
 						MCI_OPEN_PARMS mciOpenParms = { NULL, NULL, "sequencer", szSongPath, NULL };
 						dwMCIError = mciSendCommand(NULL, MCI_OPEN, MCI_OPEN_TYPE | MCI_OPEN_ELEMENT, (DWORD_PTR)&mciOpenParms);
 						if (dwMCIError) {
@@ -274,6 +285,7 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 							mciGetErrorString(dwMCIError, szErrorBuf, MAXERRORLENGTH);
 							ConsoleLog(LOG_ERROR, "MUS:  MCI_OPEN failed, 0x%08X (%s)\n", dwMCIError, szErrorBuf);
 							SetCurrentActiveSongID(0);
+							pSCApp->SCASNDLayer->dwSNDMusPlaying = 0;
 							goto next;
 						}
 
@@ -290,8 +302,12 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 							mciGetErrorString(dwMCIError, szErrorBuf, MAXERRORLENGTH);
 							ConsoleLog(LOG_ERROR, "MUS:  MCI_PLAY failed, 0x%08X (%s)\n", dwMCIError, szErrorBuf);
 							SetCurrentActiveSongID(0);
+							pSCApp->SCASNDLayer->dwSNDMusPlaying = 0;
 							goto next;
 						}
+
+						pSCApp->SCASNDLayer->wSNDMCIDevID = mciDevice;
+						pSCApp->SCASNDLayer->dwSNDMusPlaying = 1;
 					}
 					else {
 						if (mus_debug & MUS_DEBUG_THREAD && msg.lParam != 1)
@@ -312,17 +328,22 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 			}
 
 			if (pStreamCurrentSong) {
-				PostThreadMessageA(dwSDLSongThreadID, WM_SDL_STOP, 0, 0);
-				if (mus_debug & MUS_DEBUG_THREAD)
-					ConsoleLog(LOG_DEBUG, "MUS:  Thread stopped MP3 player due to WM_MUSIC_RESET message.\n");
+				if (bSongPlaying) {
+					PostThreadMessageA(dwSDLSongThreadID, WM_SDL_STOP, 0, 0);
+					if (mus_debug & MUS_DEBUG_THREAD)
+						ConsoleLog(LOG_DEBUG, "MUS:  Thread stopped MP3 player due to WM_MUSIC_RESET message.\n");
+				}
 			}
 
-			if (mciDevice) {
+			if (mciDevice != -1) {
 				dwMCIError = mciSendCommand(mciDevice, MCI_CLOSE, MCI_WAIT, NULL);
 				if (mus_debug & MUS_DEBUG_THREAD)
 					ConsoleLog(LOG_DEBUG, "MUS:  Thread stopped mciDevice 0x%08X due to WM_MUSIC_RESET message.\n", mciDevice);
-				mciDevice = NULL;
 			}
+
+			mciDevice = -1;
+			pSCApp->SCASNDLayer->wSNDMCIDevID = -1;
+			pSCApp->SCASNDLayer->dwSNDMusPlaying = 0;
 
 			// Only restart if the engine is not set to MUSIC_ENGINE_NONE
 			if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() != "none") {
@@ -341,28 +362,33 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 		DispatchMessage(&msg);
 	}
 
-	if (mciDevice)
+	if (mciDevice != -1)
 		mciSendCommand(mciDevice, MCI_CLOSE, MCI_WAIT, NULL);
+	pSCApp = &pCSimcityAppThis;
+	if (pSCApp && pSCApp->SCASNDLayer) {
+		pSCApp->SCASNDLayer->wSNDMCIDevID = -1;
+		pSCApp->SCASNDLayer->dwSNDMusPlaying = 0;
+	}
 	ConsoleLog(LOG_INFO, "MUS:  Shutting down music thread.\n");
 
 	return EXIT_SUCCESS;
 }
 
 void DoMusicPlay(int iSongID, BOOL bInterrupt) {
-	if (bInterrupt) {
+	/*if (bInterrupt)*/ {
 		// Certain songs should interrupt others
-		switch (iSongID) {
-		case 10002:
+		/*switch (iSongID)*/ {
+		/*case 10002:
 		case 10004:
 		case 10005:
 		case 10010:
 		case 10012:
-		case 10016:
+		case 10016:*/
 			if (dwMusicThreadID)
 				PostThreadMessage(dwMusicThreadID, WM_MUSIC_STOP, NULL, NULL);
 			if (mus_debug & MUS_DEBUG_THREAD)
 				ConsoleLog(LOG_DEBUG, "MUS:  Hook_SimcityApp_MusicPlay posted WM_MUSIC_STOP.\n");
-			break;
+			/*break;*/
 		}
 	}
 
@@ -446,7 +472,7 @@ extern "C" void __stdcall Hook_SimcityApp_MusicPlayNext(BOOL bNext) {
 	nSpeed = pThis->wSCAGameSpeedLOW;
 	if (nSpeed == GAME_SPEED_PAUSED)
 		nSpeed = GAME_SPEED_TURTLE;
-	if (!Game_Sound_GetMCIResult(pThis->SCASNDLayer)) {
+	if (!Game_Sound_IsMusicPlaying(pThis->SCASNDLayer)) {
 		if (bNext)
 			Game_SimcityApp_MusicPlayNextRefocusSong(pThis);
 		else if ((!(rand() % (8 * (3 * nSpeed - 3)))) || jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_ALWAYSPLAYMUSIC].ToBool()) {

--- a/modules/music.cpp
+++ b/modules/music.cpp
@@ -305,16 +305,17 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 					}
 
 					// Failing all of the above, use MCI to handle MIDI playback
+					const char* szSongPath = GetGameMusicSoundPath(FALSE);
+					if (!szSongPath || IsSongPlaying())
+						goto next;
+
 					if (mciDevice != -1) {
 						mciSendCommand(mciDevice, MCI_CLOSE, MCI_WAIT, NULL);
 						mciDevice = -1;
+						SetMCIDevID(mciDevice);
 					}
 
 					if (mciDevice == -1) {
-						const char* szSongPath = GetGameMusicSoundPath(FALSE);
-						if (!szSongPath || IsSongPlaying())
-							goto next;
-
 						SetSongPlaying(true);
 						MCI_OPEN_PARMS mciOpenParms = { NULL, NULL, "sequencer", szSongPath, NULL };
 						dwMCIError = mciSendCommand(NULL, MCI_OPEN, MCI_OPEN_TYPE | MCI_OPEN_ELEMENT, (DWORD_PTR)&mciOpenParms);
@@ -350,7 +351,6 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 					else {
 						if (mus_debug & MUS_DEBUG_THREAD)
 							ConsoleLog(LOG_DEBUG, "MUS:  WM_MUSIC_PLAY message received but MCI is still active; discarding message.\n");
-						goto next;
 					}
 				}
 			}
@@ -386,8 +386,6 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 				if (iSongID)
 					DoMusicPlay(iSongID);
 			}
-
-			goto next;
 		}
 		else if (msg.message == WM_QUIT)
 			break;

--- a/modules/music.cpp
+++ b/modules/music.cpp
@@ -21,7 +21,6 @@ std::vector<int> vectorRandomSongIDs = { 10001, 10004, 10008, 10012, 10018, 1000
 int iCurrentSong = 0;
 DWORD dwMusicThreadID = 0;
 MCIDEVICEID mciDevice = -1;
-BOOL bMultithreadedMusicEnabled = FALSE;
 bool bMusicForceIntroSongOnce = true;
 
 const char *GetGameSoundPath() {
@@ -498,8 +497,4 @@ void InstallMusicEngineHooks(void) {
 	NEWJMP((LPVOID)0x402414, Hook_SimcityApp_MusicPlay);
 	SafeVirtualProtect((LPVOID)0x402BE4, 5, PAGE_EXECUTE_READWRITE);
 	NEWJMP((LPVOID)0x402BE4, Hook_Sound_MusicStop);
-
-	// XXX - effectively always TRUE because the opt-in setting is now always TRUE as of
-	// r10-dev 2025-08-31. maybe this needs to go away?
-	bMultithreadedMusicEnabled = TRUE;
 }

--- a/modules/music.cpp
+++ b/modules/music.cpp
@@ -17,11 +17,12 @@ UINT mus_debug = MUS_DEBUG;
 static DWORD dwDummy;
 
 static int iPlayingSongID = 0;
+static MCIDEVICEID mciDevice = -1;
+static bool bMusicForceIntroSongOnce = true;
+
 std::vector<int> vectorRandomSongIDs = { 10001, 10004, 10008, 10012, 10018, 10003, 10007, 10011, 10013, 10017 };
 int iCurrentSong = 0;
 DWORD dwMusicThreadID = 0;
-MCIDEVICEID mciDevice = -1;
-bool bMusicForceIntroSongOnce = true;
 
 const char *GetGameSoundPath() {
 	return szSoundPath;
@@ -62,7 +63,7 @@ bool IsSongPlaying() {
 	return false;
 }
 
-void MusicShufflePlaylist(int iLastSongPlayed) {
+static void MusicShufflePlaylist(int iLastSongPlayed) {
 	if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SHUFFLEMUSIC].ToBool()) {
 		do {
 			std::shuffle(vectorRandomSongIDs.begin(), vectorRandomSongIDs.end(), mtMersenneTwister);
@@ -100,7 +101,7 @@ UINT MusicEngineStringToInt(const char* szMusicEngine) {
 	return MUSIC_ENGINE_SEQUENCER;
 }
 
-void WINAPI MusicMCINotifyCallback(WPARAM wFlags, LPARAM lDevID) {
+static void WINAPI MusicMCINotifyCallback(WPARAM wFlags, LPARAM lDevID) {
 	if (wFlags == MCI_NOTIFY_SUCCESSFUL || wFlags == MCI_NOTIFY_FAILURE) {
 		if (dwMusicThreadID)
 			PostThreadMessage(dwMusicThreadID, WM_MUSIC_STOP, NULL, NULL);
@@ -108,8 +109,6 @@ void WINAPI MusicMCINotifyCallback(WPARAM wFlags, LPARAM lDevID) {
 			ConsoleLog(LOG_DEBUG, "MUS:  MusicMCINotifyCallback posted WM_MUSIC_STOP. (%u, %u)\n", wFlags, lDevID);
 	}
 }
-
-const char* MusicEngineIntToString(UINT iMusicEngine);
 
 static int GetAliasIndexFromSongID(int iSongID) {
 	if (iSongID < 10000 || iSongID > 10018)

--- a/modules/music.cpp
+++ b/modules/music.cpp
@@ -36,6 +36,33 @@ int GetCurrentActiveSongID() {
 	return iPlayingSongID;
 }
 
+void SetMCIDevID(__int16 wMCIDevID) {
+	CSimcityAppPrimary *pSCApp = &pCSimcityAppThis;
+	CSound *pSound = pSCApp->SCASNDLayer;
+
+	if (pSCApp && pSound) {
+		pSound->wSNDMCIDevID = wMCIDevID;
+	}
+}
+
+void SetSongPlaying(bool bPlaying) {
+	CSimcityAppPrimary *pSCApp = &pCSimcityAppThis;
+	CSound *pSound = pSCApp->SCASNDLayer;
+
+	if (pSCApp && pSound) {
+		pSound->dwSNDMusPlaying = (bPlaying) ? 1 : 0;
+	}
+}
+
+bool IsSongPlaying() {
+	CSimcityAppPrimary *pSCApp = &pCSimcityAppThis;
+	CSound *pSound = pSCApp->SCASNDLayer;
+
+	if (pSCApp && pSound)
+		return (pSound->dwSNDMusPlaying) ? true : false;
+	return false;
+}
+
 void MusicShufflePlaylist(int iLastSongPlayed) {
 	if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SHUFFLEMUSIC].ToBool()) {
 		do {
@@ -239,8 +266,8 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 				goto next;
 			}
 			mciDevice = -1;
-			pSCApp->SCASNDLayer->wSNDMCIDevID = mciDevice;
-			pSCApp->SCASNDLayer->dwSNDMusPlaying = 0;
+			SetMCIDevID(mciDevice);
+			SetSongPlaying(false);
 		}
 		else if (msg.message == WM_MUSIC_PLAY) {
 			// Log a debug message at best if the music engine is set to none
@@ -285,10 +312,10 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 
 					if (mciDevice == -1) {
 						const char* szSongPath = GetGameMusicSoundPath(FALSE);
-						if (!szSongPath || pSCApp->SCASNDLayer->dwSNDMusPlaying)
+						if (!szSongPath || IsSongPlaying())
 							goto next;
 
-						pSCApp->SCASNDLayer->dwSNDMusPlaying = 1;
+						SetSongPlaying(true);
 						MCI_OPEN_PARMS mciOpenParms = { NULL, NULL, "sequencer", szSongPath, NULL };
 						dwMCIError = mciSendCommand(NULL, MCI_OPEN, MCI_OPEN_TYPE | MCI_OPEN_ELEMENT, (DWORD_PTR)&mciOpenParms);
 						if (dwMCIError) {
@@ -296,7 +323,7 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 							mciGetErrorString(dwMCIError, szErrorBuf, MAXERRORLENGTH);
 							ConsoleLog(LOG_ERROR, "MUS:  MCI_OPEN failed, 0x%08X (%s)\n", dwMCIError, szErrorBuf);
 							SetCurrentActiveSongID(0);
-							pSCApp->SCASNDLayer->dwSNDMusPlaying = 0;
+							SetSongPlaying(false);
 							goto next;
 						}
 
@@ -313,12 +340,12 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 							mciGetErrorString(dwMCIError, szErrorBuf, MAXERRORLENGTH);
 							ConsoleLog(LOG_ERROR, "MUS:  MCI_PLAY failed, 0x%08X (%s)\n", dwMCIError, szErrorBuf);
 							SetCurrentActiveSongID(0);
-							pSCApp->SCASNDLayer->dwSNDMusPlaying = 0;
+							SetSongPlaying(false);
 							goto next;
 						}
 
-						pSCApp->SCASNDLayer->wSNDMCIDevID = mciDevice;
-						pSCApp->SCASNDLayer->dwSNDMusPlaying = 1;
+						SetMCIDevID(mciDevice);
+						SetSongPlaying(true);
 					}
 					else {
 						if (mus_debug & MUS_DEBUG_THREAD)
@@ -331,19 +358,15 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 		else if (msg.message == WM_MUSIC_RESET) {
 			// Attempt to hard stop all music engines, since our music engine has probably changed
 			if (hmodFluidSynth) {
-				if (bFluidSynthPlaying) {
-					PostThreadMessageA(dwFSMIDIThreadID, WM_FS_STOP, 0, 0);
-					if (mus_debug & MUS_DEBUG_THREAD)
-						ConsoleLog(LOG_DEBUG, "MUS:  Thread stopped FluidSynth player due to WM_MUSIC_RESET message.\n");
-				}
+				PostThreadMessageA(dwFSMIDIThreadID, WM_FS_STOP, 0, 0);
+				if (mus_debug & MUS_DEBUG_THREAD)
+					ConsoleLog(LOG_DEBUG, "MUS:  Thread stopped FluidSynth player due to WM_MUSIC_RESET message.\n");
 			}
 
 			if (pStreamCurrentSong) {
-				if (bSongPlaying) {
-					PostThreadMessageA(dwSDLSongThreadID, WM_SDL_STOP, 0, 0);
-					if (mus_debug & MUS_DEBUG_THREAD)
-						ConsoleLog(LOG_DEBUG, "MUS:  Thread stopped MP3 player due to WM_MUSIC_RESET message.\n");
-				}
+				PostThreadMessageA(dwSDLSongThreadID, WM_SDL_STOP, 0, 0);
+				if (mus_debug & MUS_DEBUG_THREAD)
+					ConsoleLog(LOG_DEBUG, "MUS:  Thread stopped MP3 player due to WM_MUSIC_RESET message.\n");
 			}
 
 			if (mciDevice != -1) {
@@ -353,15 +376,15 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 			}
 
 			mciDevice = -1;
-			pSCApp->SCASNDLayer->wSNDMCIDevID = -1;
-			pSCApp->SCASNDLayer->dwSNDMusPlaying = 0;
+			SetMCIDevID(mciDevice);
+			SetSongPlaying(false);
 
 			// Only restart if the engine is not set to MUSIC_ENGINE_NONE
 			if (jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICDRIVER].ToString() != "none") {
 				// Restart the active song if there is one
 				int iSongID = GetCurrentActiveSongID();
 				if (iSongID)
-					DoMusicPlay(iSongID, FALSE);
+					DoMusicPlay(iSongID);
 			}
 
 			goto next;
@@ -373,13 +396,12 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 		DispatchMessage(&msg);
 	}
 
-	if (mciDevice != -1)
+	if (mciDevice != -1) {
 		mciSendCommand(mciDevice, MCI_CLOSE, MCI_WAIT, NULL);
-	pSCApp = &pCSimcityAppThis;
-	if (pSCApp && pSCApp->SCASNDLayer) {
-		pSCApp->SCASNDLayer->wSNDMCIDevID = -1;
-		pSCApp->SCASNDLayer->dwSNDMusPlaying = 0;
+		mciDevice = -1;
 	}
+	SetMCIDevID(mciDevice);
+	SetSongPlaying(false);
 	ConsoleLog(LOG_INFO, "MUS:  Shutting down music thread.\n");
 
 	return EXIT_SUCCESS;

--- a/modules/music.cpp
+++ b/modules/music.cpp
@@ -194,20 +194,6 @@ const char *GetGameMusicSoundPath(BOOL bDoMP3) {
 	return strSongPath.c_str();
 }
 
-static void DoMusicPlay(int iSongID) {
-	// Always do this.
-	if (dwMusicThreadID)
-		PostThreadMessage(dwMusicThreadID, WM_MUSIC_STOP, NULL, NULL);
-	if (mus_debug & MUS_DEBUG_THREAD)
-		ConsoleLog(LOG_DEBUG, "MUS:  Hook_SimcityApp_MusicPlay posted WM_MUSIC_STOP.\n");
-
-	// Post the play message to the music thread
-	if (dwMusicThreadID)
-		PostThreadMessage(dwMusicThreadID, WM_MUSIC_PLAY, iSongID, NULL);
-	if (mus_debug & MUS_DEBUG_THREAD)
-		ConsoleLog(LOG_DEBUG, "MUS:  Hook_SimcityApp_MusicPlay posted WM_MUSIC_PLAY for iSongID = %u.\n", iSongID);
-}
-
 DWORD WINAPI MusicThread(LPVOID lpParameter) {
 	CSimcityAppPrimary *pSCApp;
 	MSG msg;
@@ -383,7 +369,7 @@ DWORD WINAPI MusicThread(LPVOID lpParameter) {
 				// Restart the active song if there is one
 				int iSongID = GetCurrentActiveSongID();
 				if (iSongID)
-					DoMusicPlay(iSongID);
+					Game_SimcityApp_MusicPlay(pSCApp, iSongID);
 			}
 		}
 		else if (msg.message == WM_QUIT)
@@ -415,8 +401,19 @@ extern "C" void __stdcall Hook_SimcityApp_MusicPlay(int iSongID) {
 	CSimcityAppPrimary *pThis;
 	__asm mov [pThis], ecx
 
-	if (pThis->dwSCAGameMusic)
-		DoMusicPlay(iSongID);
+	if (pThis->dwSCAGameMusic) {
+		// Always do this.
+		if (dwMusicThreadID)
+			PostThreadMessage(dwMusicThreadID, WM_MUSIC_STOP, NULL, NULL);
+		if (mus_debug & MUS_DEBUG_THREAD)
+			ConsoleLog(LOG_DEBUG, "MUS:  Hook_SimcityApp_MusicPlay posted WM_MUSIC_STOP.\n");
+
+		// Post the play message to the music thread
+		if (dwMusicThreadID)
+			PostThreadMessage(dwMusicThreadID, WM_MUSIC_PLAY, iSongID, NULL);
+		if (mus_debug & MUS_DEBUG_THREAD)
+			ConsoleLog(LOG_DEBUG, "MUS:  Hook_SimcityApp_MusicPlay posted WM_MUSIC_PLAY for iSongID = %u.\n", iSongID);
+	}
 }
 
 extern "C" void __stdcall Hook_Sound_MusicStop(void) {

--- a/modules/sc2x.cpp
+++ b/modules/sc2x.cpp
@@ -41,7 +41,6 @@ UINT sc2x_debug = SC2X_DEBUG;
 
 static char* szLoadFileName = NULL;
 static int iCorruptedFixupSize = 0;
-static DWORD dwDummy;
 
 void LoadInterleavedBudgetVanilla(budget_t* pTarget, DWORD* pSource) {
 	pTarget->iCurrentCosts = ntohl(pSource[0]);

--- a/modules/scenario_status.cpp
+++ b/modules/scenario_status.cpp
@@ -24,8 +24,6 @@
 
 UINT scenstat_debug = SCENSTAT_DEBUG;
 
-static DWORD dwDummy;
-
 // Scenario locals; read on scenario load
 const char* scScenarioDescription = NULL;
 DWORD dwScenarioStartDays = 0;

--- a/modules/scurkfix_1996.cpp
+++ b/modules/scurkfix_1996.cpp
@@ -14,8 +14,6 @@
 
 #include <sc2kfix.h>
 
-static DWORD dwDummy;
-
 extern "C" void __cdecl Hook_SCURK1996_DebugOut(char const *fmt, ...) {
 	va_list args;
 

--- a/modules/scurkfix_primary.cpp
+++ b/modules/scurkfix_primary.cpp
@@ -14,8 +14,6 @@
 
 #include <sc2kfix.h>
 
-static DWORD dwDummy;
-
 // Commented out but retained, just in case any manual VTable entry
 // confirmation checks are needed.
 /*

--- a/modules/settings.cpp
+++ b/modules/settings.cpp
@@ -15,8 +15,6 @@
 #include <keybindings.h>
 #include "../resource.h"
 
-static DWORD dwDummy;
-
 HOOKEXT_CPP json::JSON jsonSettingsCore;
 HOOKEXT_CPP json::JSON jsonSettingsMods;
 json::JSON jsonSettingsCoreWorkingCopy;

--- a/modules/sound_engine.cpp
+++ b/modules/sound_engine.cpp
@@ -49,25 +49,24 @@ const char* (*SDL_GetError)(void);
 bool (*SDL_MixAudio)(uint8_t* dst, const uint8_t* src, SDL_AudioFormat format, uint32_t len, float volume);
 bool (*SDL_SetAudioStreamGain)(SDL_AudioStream* stream, float gain);
 
-HMODULE hmodSndFile = NULL;
-HMODULE hmodSDL3 = NULL;
+static HMODULE hmodSndFile = NULL;
+static HMODULE hmodSDL3 = NULL;
+
+static HANDLE hCurrentSongThread = NULL;
+static HANDLE hCurrentSoundThread = NULL;
+static bool bSoundPlaying = false;
+
+static bool bSongStop = false;
+static bool bSoundStop = false;
+
+static bool bSongThreadActive = false;
+static bool bSoundThreadActive[2] = { false, false };
 
 DWORD dwSDLSoundThreadID = 0;
 DWORD dwSDLSongThreadID = 0;
 
-int iCurrentSongID = 0;
-int iCurrentSoundID = 0;
 SDL_AudioStream* pStreamCurrentSong = NULL;
 SDL_AudioStream* pStreamCurrentSound = NULL;
-HANDLE hCurrentSongThread = NULL;
-HANDLE hCurrentSoundThread = NULL;
-bool bSoundPlaying = false;
-
-bool bSongStop = false;
-bool bSoundStop = false;
-
-bool bSongThreadActive = false;
-bool bSoundThreadActive[2] = { false, false };
 
 #define MAX_START 35
 

--- a/modules/sound_engine.cpp
+++ b/modules/sound_engine.cpp
@@ -266,8 +266,7 @@ DWORD WINAPI SDLSongThread(LPVOID lpParameter) {
 					if (sdl_debug & SDL_DEBUG_SONG)
 						ConsoleLog(LOG_DEBUG, "MUS:  Playing MP3 file \"%s\" via SDL3.\n", szSongPath);
 					SoundEnginePlaySong(&pStreamCurrentSong, &stAudioEntityMP3,
-						jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICVOLUME].ToFloat() * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MASTERVOLUME].ToFloat(),
-						true);
+						jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICVOLUME].ToFloat() * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MASTERVOLUME].ToFloat());
 				}
 			}
 		}
@@ -465,14 +464,11 @@ void SoundEngineStopSong(SDL_AudioStream** pStream) {
 	bSongPlaying = false;
 }
 
-bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume, bool bOverride) {
+bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume) {
 	CSimcityAppPrimary *pSCApp = &pCSimcityAppThis;
 	CSound *pSound = pSCApp->SCASNDLayer;
 
 	if (!pStream || !stAudioData)
-		return false;
-
-	if (!bOverride && bSongPlaying)
 		return false;
 	
 	StopCurrentSong(pStream);

--- a/modules/sound_engine.cpp
+++ b/modules/sound_engine.cpp
@@ -61,7 +61,6 @@ SDL_AudioStream* pStreamCurrentSong = NULL;
 SDL_AudioStream* pStreamCurrentSound = NULL;
 HANDLE hCurrentSongThread = NULL;
 HANDLE hCurrentSoundThread = NULL;
-bool bSongPlaying = false;
 bool bSoundPlaying = false;
 
 bool bSongStop = false;
@@ -212,8 +211,8 @@ static void StopCurrentSong(SDL_AudioStream** pStream) {
 		}
 	}
 
-	pSound->wSNDMCIDevID = -1;
-	pSound->dwSNDMusPlaying = 0;
+	SetMCIDevID(-1);
+	SetSongPlaying(false);
 }
 
 DWORD WINAPI SDLSongThread(LPVOID lpParameter) {
@@ -227,7 +226,7 @@ DWORD WINAPI SDLSongThread(LPVOID lpParameter) {
 	while (GetMessage(&msg, NULL, 0, 0)) {
 		if (msg.message == WM_SDL_PLAY) {
 			if (msg.wParam >= 10000 && msg.wParam <= 10018) {
-				if (bSongPlaying)
+				if (IsSongPlaying())
 					goto next;
 				const char* szSongPath = GetGameMusicSoundPath(TRUE);
 				if (szSongPath) {
@@ -321,7 +320,8 @@ DWORD WINAPI SoundEngineSongThread(LPVOID lpParameter) {
 	}
 
 	bSongThreadActive = false;
-	bSongPlaying = false;
+	SetMCIDevID(-1);
+	SetSongPlaying(false);
 	return EXIT_SUCCESS;
 }
 
@@ -460,8 +460,6 @@ void SoundEngineStopSong(SDL_AudioStream** pStream) {
 		return;
 	if (*pStream)
 		SDL_ClearAudioStream(*pStream);
-
-	bSongPlaying = false;
 }
 
 bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume) {
@@ -482,10 +480,8 @@ bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData,
 	SDL_SetAudioStreamGain(*pStream, fVolume);
 	SDL_PutAudioStreamData(*pStream, stAudioData->pBuffer, stAudioData->uBufferSize);
 	SDL_ResumeAudioStreamDevice(*pStream);
-	bSongPlaying = true;
 
-	pSound->wSNDMCIDevID = 1;
-	pSound->dwSNDMusPlaying = 1;
+	SetSongPlaying(true);
 
 	hCurrentSongThread = CreateThread(NULL, 0, SoundEngineSongThread, stAudioData, 0, NULL);
 

--- a/modules/sound_engine.cpp
+++ b/modules/sound_engine.cpp
@@ -183,6 +183,9 @@ DWORD WINAPI SDLSoundThread(LPVOID lpParameter) {
 }
 
 static void StopCurrentSong(SDL_AudioStream** pStream) {
+	CSimcityAppPrimary *pSCApp = &pCSimcityAppThis;
+	CSound *pSound = pSCApp->SCASNDLayer;
+
 	if (*pStream) {
 		if (bSongThreadActive) {
 			if (hCurrentSongThread) {
@@ -208,6 +211,9 @@ static void StopCurrentSong(SDL_AudioStream** pStream) {
 			SoundEngineStopSong(pStream);
 		}
 	}
+
+	pSound->wSNDMCIDevID = -1;
+	pSound->dwSNDMusPlaying = 0;
 }
 
 DWORD WINAPI SDLSongThread(LPVOID lpParameter) {
@@ -460,6 +466,9 @@ void SoundEngineStopSong(SDL_AudioStream** pStream) {
 }
 
 bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume, bool bOverride) {
+	CSimcityAppPrimary *pSCApp = &pCSimcityAppThis;
+	CSound *pSound = pSCApp->SCASNDLayer;
+
 	if (!pStream || !stAudioData)
 		return false;
 
@@ -478,6 +487,9 @@ bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData,
 	SDL_PutAudioStreamData(*pStream, stAudioData->pBuffer, stAudioData->uBufferSize);
 	SDL_ResumeAudioStreamDevice(*pStream);
 	bSongPlaying = true;
+
+	pSound->wSNDMCIDevID = 1;
+	pSound->dwSNDMusPlaying = 1;
 
 	hCurrentSongThread = CreateThread(NULL, 0, SoundEngineSongThread, stAudioData, 0, NULL);
 

--- a/modules/sound_engine.cpp
+++ b/modules/sound_engine.cpp
@@ -70,6 +70,15 @@ SDL_AudioStream* pStreamCurrentSound = NULL;
 
 #define MAX_START 35
 
+static void SoundEngineStopStream(SDL_AudioStream** pStream) {
+	if (!pStream)
+		return;
+	if (*pStream)
+		SDL_ClearAudioStream(*pStream);
+
+	bSoundPlaying = false;
+}
+
 static void StopCurrentSound(SDL_AudioStream** pStream) {
 	if (*pStream) {
 		if (bSoundThreadActive[0] || bSoundThreadActive[1]) {
@@ -104,6 +113,78 @@ static void StopCurrentSound(SDL_AudioStream** pStream) {
 			SoundEngineStopStream(pStream);
 		}
 	}
+}
+
+static DWORD WINAPI SoundEngineOneShotThread(LPVOID lpParameter) {
+	audio_entity_t* stAudioData = (audio_entity_t*)lpParameter;
+
+	if (bSoundThreadActive[0])
+		return EXIT_SUCCESS;
+	bSoundThreadActive[0] = true;
+	bSoundStop = false;
+	while (SDL_GetAudioStreamAvailable(pStreamCurrentSound) > 0) {
+		if (bSoundStop || !pStreamCurrentSound)
+			break;
+		Sleep(10);
+	}
+
+	bSoundThreadActive[0] = false;
+	bSoundPlaying = false;
+	return EXIT_SUCCESS;
+}
+
+static DWORD WINAPI SoundEngineLoopThread(LPVOID lpParameter) {
+	audio_entity_t* stAudioData = (audio_entity_t*)lpParameter;
+
+	if (bSoundThreadActive[1])
+		return EXIT_SUCCESS;
+	bSoundThreadActive[1] = true;
+	bSoundStop = false;
+	for (;;) {
+		if (bSoundStop || !bSoundPlaying || !pStreamCurrentSound)
+			break;
+		if (SDL_GetAudioStreamAvailable(pStreamCurrentSound) < stAudioData->uBufferSize)
+			SDL_PutAudioStreamData(pStreamCurrentSound, stAudioData->pBuffer, stAudioData->uBufferSize);
+		Sleep(10);
+	}
+
+	bSoundThreadActive[1] = false;
+	return EXIT_SUCCESS;
+}
+
+static bool SoundEnginePlayStream(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume, bool bOverride, bool bLoop) {
+	if (!pStream || !stAudioData)
+		return false;
+
+	if (!bOverride && bSoundPlaying)
+		return false;
+
+	StopCurrentSound(pStream);
+
+	SDL_AudioSpec spec = {
+		SDL_AUDIO_S16,
+		stAudioData->iChannels,
+		stAudioData->iSampleRate
+	};
+
+	SDL_SetAudioStreamFormat(*pStream, &spec, NULL);
+	SDL_SetAudioStreamGain(*pStream, fVolume);
+	SDL_PutAudioStreamData(*pStream, stAudioData->pBuffer, stAudioData->uBufferSize);
+	SDL_ResumeAudioStreamDevice(*pStream);
+	bSoundPlaying = true;
+
+	if (bLoop)
+		hCurrentSoundThread = CreateThread(NULL, 0, SoundEngineLoopThread, stAudioData, 0, NULL);
+	else
+		hCurrentSoundThread = CreateThread(NULL, 0, SoundEngineOneShotThread, stAudioData, 0, NULL);
+
+	if (!hCurrentSoundThread) {
+		StopCurrentSound(pStream);
+		return false;
+	}
+
+	SetThreadPriority(hCurrentSoundThread, THREAD_PRIORITY_TIME_CRITICAL);
+	return true;
 }
 
 DWORD WINAPI SDLSoundThread(LPVOID lpParameter) {
@@ -180,6 +261,13 @@ DWORD WINAPI SDLSoundThread(LPVOID lpParameter) {
 	return EXIT_SUCCESS;
 }
 
+static void SoundEngineStopSong(SDL_AudioStream** pStream) {
+	if (!pStream)
+		return;
+	if (*pStream)
+		SDL_ClearAudioStream(*pStream);
+}
+
 static void StopCurrentSong(SDL_AudioStream** pStream) {
 	if (*pStream) {
 		if (bSongThreadActive) {
@@ -209,6 +297,54 @@ static void StopCurrentSong(SDL_AudioStream** pStream) {
 
 	SetMCIDevID(-1);
 	SetSongPlaying(false);
+}
+
+static DWORD WINAPI SoundEngineSongThread(LPVOID lpParameter) {
+	audio_entity_t* stAudioData = (audio_entity_t*)lpParameter;
+
+	if (bSongThreadActive)
+		return EXIT_SUCCESS;
+	bSongThreadActive = true;
+	bSongStop = false;
+	while (SDL_GetAudioStreamAvailable(pStreamCurrentSong) > 0) {
+		if (bSongStop || !pStreamCurrentSong)
+			break;
+		Sleep(10);
+	}
+
+	bSongThreadActive = false;
+	SetMCIDevID(-1);
+	SetSongPlaying(false);
+	return EXIT_SUCCESS;
+}
+
+static bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume) {
+	if (!pStream || !stAudioData)
+		return false;
+
+	StopCurrentSong(pStream);
+
+	SDL_AudioSpec spec = {
+		SDL_AUDIO_S16,
+		stAudioData->iChannels,
+		stAudioData->iSampleRate
+	};
+
+	SDL_SetAudioStreamGain(*pStream, fVolume);
+	SDL_PutAudioStreamData(*pStream, stAudioData->pBuffer, stAudioData->uBufferSize);
+	SDL_ResumeAudioStreamDevice(*pStream);
+
+	SetSongPlaying(true);
+
+	hCurrentSongThread = CreateThread(NULL, 0, SoundEngineSongThread, stAudioData, 0, NULL);
+
+	if (!hCurrentSongThread) {
+		StopCurrentSong(pStream);
+		return false;
+	}
+
+	SetThreadPriority(hCurrentSongThread, THREAD_PRIORITY_TIME_CRITICAL);
+	return true;
 }
 
 DWORD WINAPI SDLSongThread(LPVOID lpParameter) {
@@ -284,62 +420,6 @@ next:
 	return EXIT_SUCCESS;
 }
 
-DWORD WINAPI SoundEngineOneShotThread(LPVOID lpParameter) {
-	audio_entity_t* stAudioData = (audio_entity_t*)lpParameter;
-
-	if (bSoundThreadActive[0])
-		return EXIT_SUCCESS;
-	bSoundThreadActive[0] = true;
-	bSoundStop = false;
-	while (SDL_GetAudioStreamAvailable(pStreamCurrentSound) > 0) {
-		if (bSoundStop || !pStreamCurrentSound)
-			break;
-		Sleep(10);
-	}
-
-	bSoundThreadActive[0] = false;
-	bSoundPlaying = false;
-	return EXIT_SUCCESS;
-}
-
-DWORD WINAPI SoundEngineSongThread(LPVOID lpParameter) {
-	audio_entity_t* stAudioData = (audio_entity_t*)lpParameter;
-
-	if (bSongThreadActive)
-		return EXIT_SUCCESS;
-	bSongThreadActive = true;
-	bSongStop = false;
-	while (SDL_GetAudioStreamAvailable(pStreamCurrentSong) > 0) {
-		if (bSongStop || !pStreamCurrentSong)
-			break;
-		Sleep(10);
-	}
-
-	bSongThreadActive = false;
-	SetMCIDevID(-1);
-	SetSongPlaying(false);
-	return EXIT_SUCCESS;
-}
-
-DWORD WINAPI SoundEngineLoopThread(LPVOID lpParameter) {
-	audio_entity_t* stAudioData = (audio_entity_t*)lpParameter;
-
-	if (bSoundThreadActive[1])
-		return EXIT_SUCCESS;
-	bSoundThreadActive[1] = true;
-	bSoundStop = false;
-	for (;;) {
-		if (bSoundStop || !bSoundPlaying || !pStreamCurrentSound)
-			break;
-		if (SDL_GetAudioStreamAvailable(pStreamCurrentSound) < stAudioData->uBufferSize)
-			SDL_PutAudioStreamData(pStreamCurrentSound, stAudioData->pBuffer, stAudioData->uBufferSize);
-		Sleep(10);
-	}
-
-	bSoundThreadActive[1] = false;
-	return EXIT_SUCCESS;
-}
-
 bool LoadSoundEngineLibraries(void) {
 	hmodSndFile = LoadLibrary("sndfile.dll");
 	if (!hmodSndFile) {
@@ -405,84 +485,4 @@ void SoundEngineDestroy(void) {
 
 	if (sdl_debug & SDL_DEBUG_GENERAL)
 		ConsoleLog(LOG_DEBUG, "SND: SDL Sound Engine Destroyed.\n");
-}
-
-void SoundEngineStopStream(SDL_AudioStream** pStream) {
-	if (!pStream)
-		return;
-	if (*pStream)
-		SDL_ClearAudioStream(*pStream);
-
-	bSoundPlaying = false;
-}
-
-bool SoundEnginePlayStream(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume, bool bOverride, bool bLoop) {
-	if (!pStream || !stAudioData)
-		return false;
-
-	if (!bOverride && bSoundPlaying)
-		return false;
-	
-	StopCurrentSound(pStream);
-
-	SDL_AudioSpec spec = {
-		SDL_AUDIO_S16,
-		stAudioData->iChannels,
-		stAudioData->iSampleRate
-	};
-
-	SDL_SetAudioStreamFormat(*pStream, &spec, NULL);
-	SDL_SetAudioStreamGain(*pStream, fVolume);
-	SDL_PutAudioStreamData(*pStream, stAudioData->pBuffer, stAudioData->uBufferSize);
-	SDL_ResumeAudioStreamDevice(*pStream);
-	bSoundPlaying = true;
-
-	if (bLoop)
-		hCurrentSoundThread = CreateThread(NULL, 0, SoundEngineLoopThread, stAudioData, 0, NULL);
-	else
-		hCurrentSoundThread = CreateThread(NULL, 0, SoundEngineOneShotThread, stAudioData, 0, NULL);
-
-	if (!hCurrentSoundThread) {
-		StopCurrentSound(pStream);
-		return false;
-	}
-
-	SetThreadPriority(hCurrentSoundThread, THREAD_PRIORITY_TIME_CRITICAL);
-	return true;
-}
-
-void SoundEngineStopSong(SDL_AudioStream** pStream) {
-	if (!pStream)
-		return;
-	if (*pStream)
-		SDL_ClearAudioStream(*pStream);
-}
-
-bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume) {
-	if (!pStream || !stAudioData)
-		return false;
-	
-	StopCurrentSong(pStream);
-
-	SDL_AudioSpec spec = {
-		SDL_AUDIO_S16,
-		stAudioData->iChannels,
-		stAudioData->iSampleRate
-	};
-
-	SDL_SetAudioStreamGain(*pStream, fVolume);
-	SDL_PutAudioStreamData(*pStream, stAudioData->pBuffer, stAudioData->uBufferSize);
-	SDL_ResumeAudioStreamDevice(*pStream);
-
-	SetSongPlaying(true);
-
-	hCurrentSongThread = CreateThread(NULL, 0, SoundEngineSongThread, stAudioData, 0, NULL);
-
-	if (!hCurrentSongThread) {
-		StopCurrentSong(pStream);
-		return false;
-	}
-
-	SetThreadPriority(hCurrentSongThread, THREAD_PRIORITY_TIME_CRITICAL);
-	return true;
 }

--- a/modules/sound_engine.cpp
+++ b/modules/sound_engine.cpp
@@ -182,9 +182,6 @@ DWORD WINAPI SDLSoundThread(LPVOID lpParameter) {
 }
 
 static void StopCurrentSong(SDL_AudioStream** pStream) {
-	CSimcityAppPrimary *pSCApp = &pCSimcityAppThis;
-	CSound *pSound = pSCApp->SCASNDLayer;
-
 	if (*pStream) {
 		if (bSongThreadActive) {
 			if (hCurrentSongThread) {
@@ -463,9 +460,6 @@ void SoundEngineStopSong(SDL_AudioStream** pStream) {
 }
 
 bool SoundEnginePlaySong(SDL_AudioStream** pStream, audio_entity_t* stAudioData, float fVolume) {
-	CSimcityAppPrimary *pSCApp = &pCSimcityAppThis;
-	CSound *pSound = pSCApp->SCASNDLayer;
-
 	if (!pStream || !stAudioData)
 		return false;
 	

--- a/modules/sound_engine.cpp
+++ b/modules/sound_engine.cpp
@@ -143,7 +143,7 @@ static DWORD WINAPI SoundEngineLoopThread(LPVOID lpParameter) {
 	for (;;) {
 		if (bSoundStop || !bSoundPlaying || !pStreamCurrentSound)
 			break;
-		if (SDL_GetAudioStreamAvailable(pStreamCurrentSound) < stAudioData->uBufferSize)
+		if (SDL_GetAudioStreamAvailable(pStreamCurrentSound) < (int)stAudioData->uBufferSize)
 			SDL_PutAudioStreamData(pStreamCurrentSound, stAudioData->pBuffer, stAudioData->uBufferSize);
 		Sleep(10);
 	}
@@ -207,7 +207,7 @@ DWORD WINAPI SDLSoundThread(LPVOID lpParameter) {
 			if (sdl_debug & SDL_DEBUG_SOUND)
 				ConsoleLog(LOG_DEBUG, "SDLSoundThread: WM_SDL_PLAY: (%d) (%d) %d\n", soundAttrib.iSoundID, nDuration, soundAttrib.nOrig);
 			
-			fVolume = jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SOUNDVOLUME].ToFloat() * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MASTERVOLUME].ToFloat();
+			fVolume = float(jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_SOUNDVOLUME].ToFloat() * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MASTERVOLUME].ToFloat());
 
 			pSCApp = &pCSimcityAppThis;
 			if (pSCApp) {
@@ -374,11 +374,11 @@ DWORD WINAPI SDLSongThread(LPVOID lpParameter) {
 					}
 
 					// Build the audio entity data
-					stAudioEntityMP3.iFrames = stInfoMP3File.frames;
+					stAudioEntityMP3.iFrames = (int)stInfoMP3File.frames;
 					stAudioEntityMP3.iSampleRate = stInfoMP3File.samplerate;
 					stAudioEntityMP3.iChannels = stInfoMP3File.channels;
 					stAudioEntityMP3.iFormat = stInfoMP3File.format;
-					stAudioEntityMP3.bSeekable = stInfoMP3File.seekable;
+					stAudioEntityMP3.bSeekable = stInfoMP3File.seekable ? true : false;
 					stAudioEntityMP3.uBufferSize = stAudioEntityMP3.iChannels * sizeof(short) * stAudioEntityMP3.iFrames;
 					stAudioEntityMP3.pBuffer = (short*)malloc(stAudioEntityMP3.uBufferSize);
 					if (!stAudioEntityMP3.pBuffer) {
@@ -397,7 +397,7 @@ DWORD WINAPI SDLSongThread(LPVOID lpParameter) {
 					if (sdl_debug & SDL_DEBUG_SONG)
 						ConsoleLog(LOG_DEBUG, "MUS:  Playing MP3 file \"%s\" via SDL3.\n", szSongPath);
 					SoundEnginePlaySong(&pStreamCurrentSong, &stAudioEntityMP3,
-						jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICVOLUME].ToFloat() * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MASTERVOLUME].ToFloat());
+						float(jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MUSICVOLUME].ToFloat() * jsonSettingsCore[C_SC2KFIX][S_FIX_AUDIO][I_FIX_AUD_MASTERVOLUME].ToFloat()));
 				}
 			}
 		}

--- a/modules/status_dialog.cpp
+++ b/modules/status_dialog.cpp
@@ -24,8 +24,6 @@
 
 #define GOTO_IMG_POS    12
 
-static DWORD dwDummy;
-
 HANDLE hWeatherBitmaps[13];
 HANDLE hCompassBitmaps[4];
 BOOL bStatusDialogMoving = FALSE;


### PR DESCRIPTION
1) Remove the override/interrupt boolean that was previously used for forcing certain tracks - it's no longer needed.
2) A bit more demystification concerning internal var/function names for better integration (links to (1)).
3) Scope and ordering adjustments of various sound/music-related calls in their respective source files/headers.
4) Remnants of the original multi-threaded music boolean have been removed.
5) Remove original 'dwDummy" source-specific-level static vars (outlier - but no longer needed).